### PR TITLE
[codex] Migrate Android to LiteRT-LM and refresh Gemma 4 example

### DIFF
--- a/CapgoCapacitorLlm.podspec
+++ b/CapgoCapacitorLlm.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.dependency 'Capacitor'
   s.dependency 'MediaPipeTasksGenAI'
   s.dependency 'MediaPipeTasksGenAIC'
-  s.swift_version = '5.1'
+  s.swift_version = '6.0'
 end

--- a/README.md
+++ b/README.md
@@ -7,24 +7,28 @@
   <h2><a href="https://capgo.app/consulting/?ref=plugin_llm"> Fix your annoying bug now, Hire a Capacitor expert 💪</a></h2>
 </div>
 
-Adds support for LLM locally run for Capacitor
+On-device LLM support for Capacitor.
 
-It uses Apple Intelligence (default) or MediaPipe custom models on iOS, and MediaPipe's tasks-genai on Android
+Current platform strategy:
+
+- iOS: Apple Intelligence by default, plus legacy custom MediaPipe models
+- Android: LiteRT-LM for `.litertlm` bundles, with a compatibility fallback for legacy MediaPipe `.task` models
+- Web: MediaPipe `@mediapipe/tasks-genai`
 
 ## Documentation
 
-The most complete doc is available here: https://capgo.app/docs/plugins/llm/
+The most complete plugin docs are available at [capgo.app/docs/plugins/llm](https://capgo.app/docs/plugins/llm/).
 
 ## Compatibility
 
 | Plugin version | Capacitor compatibility | Maintained |
 | -------------- | ----------------------- | ---------- |
-| v8.\*.\*       | v8.\*.\*                | ✅          |
-| v7.\*.\*       | v7.\*.\*                | On demand   |
-| v6.\*.\*       | v6.\*.\*                | ❌          |
-| v5.\*.\*       | v5.\*.\*                | ❌          |
+| v8.*.*         | v8.*.*                  | ✅         |
+| v7.*.*         | v7.*.*                  | On demand  |
+| v6.*.*         | v6.*.*                  | ❌         |
+| v5.*.*         | v5.*.*                  | ❌         |
 
-> **Note:** The major version of this plugin follows the major version of Capacitor. Use the version that matches your Capacitor installation (e.g., plugin v8 for Capacitor 8). Only the latest major version is actively maintained.
+> **Note:** The plugin major version follows the Capacitor major version. Use the version that matches your Capacitor installation.
 
 ## Installation
 
@@ -33,256 +37,123 @@ npm install @capgo/capacitor-llm
 npx cap sync
 ```
 
-### iOS Additional Setup for Custom Models
+If you use the web implementation, also install the MediaPipe peer dependency:
 
-If you want to use custom models on iOS (not just Apple Intelligence), you need to install MediaPipe dependencies.
-
-**Using CocoaPods:**
-The MediaPipe dependencies are already configured in the podspec. Make sure to run `pod install` after adding the plugin.
-
-**Note about Static Framework Warning:**
-When running `pod install`, you may see a warning about transitive dependencies with statically linked binaries. To fix this, update your Podfile:
-
-```ruby
-# Change this:
-use_frameworks!
-
-# To this:
-use_frameworks! :linkage => :static
-
-# And add this to your post_install hook:
-post_install do |installer|
-  assertDeploymentTarget(installer)
-  
-  # Fix for static framework dependencies
-  installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
-    end
-    
-    # Specifically for MediaPipe pods
-    if target.name.include?('MediaPipeTasksGenAI')
-      target.build_configurations.each do |config|
-        config.build_settings['ENABLE_BITCODE'] = 'NO'
-      end
-    end
-  end
-end
+```bash
+npm install @mediapipe/tasks-genai
 ```
 
-**Using Swift Package Manager:**
-
-MediaPipe GenAI does not officially support SPM yet (see [MediaPipe issue #5464](https://github.com/google-ai-edge/mediapipe/issues/5464)). However, you can use the community package [SwiftTasksGenAI](https://github.com/paescebu/SwiftTasksGenAI) by adding it manually in Xcode:
-
-**To add MediaPipe GenAI via SPM:**
-1. Open your app project in Xcode
-2. Go to **File > Add Package Dependencies...**
-3. Enter the URL: `https://github.com/paescebu/SwiftTasksGenAI.git`
-4. Select your desired version (e.g., 0.10.24)
-5. Add the `SwiftTasksGenAI` product to your app target
-
-**Note:** SwiftTasksGenAI uses unsafe build flags, which means it cannot be added directly in Package.swift files, but works fine when added through Xcode's UI. This is the same approach used by SwiftTasksVision.
-
-**Alternatively:** Use CocoaPods for a more traditional setup, or use Apple Intelligence (iOS 18.2+) which works with both SPM and CocoaPods.
-
-## Adding a Model to Your App
+## Model Setup
 
 ### iOS
 
-On iOS, you have two options:
+Recommended path:
 
-1. **Apple Intelligence (Default)**: Uses the built-in system model (requires iOS 26.0+) - Recommended
-2. **Custom Models**: Use your own models via MediaPipe (requires CocoaPods) - Note: Some model formats may have compatibility issues
+- Use Apple Intelligence with `path: 'Apple Intelligence'`
+- Requires iOS 26.0+
 
-#### Using Apple Intelligence (Default)
+Custom iOS model path:
 
-No additional setup needed. The plugin will automatically use Apple Intelligence on supported devices (iOS 26.0+).
+- Still uses the existing MediaPipe integration
+- Requires CocoaPods for `MediaPipeTasksGenAI`
+- Best treated as experimental compared with Apple Intelligence
 
-#### Using Custom Models on iOS via MediaPipe
+Example:
 
-**⚠️ IMPORTANT**: While MediaPipe documentation states Gemma-2 2B works on all platforms, iOS implementation has compatibility issues with `.task` format models, often resulting in `(prefill_input_names.size() % 2)==(0)` errors.
-
-## Model Compatibility Guide
-
-### Android (Working ✅)
-- **Model**: Gemma-3 models (270M, 1B, etc.)
-- **Format**: `.task` + `.litertlm` files
-- **Where to download**: 
-  - [Kaggle Gemma models](https://www.kaggle.com/models/google/gemma) - "LiteRT (formerly TFLite)" tab
-  - Example: `gemma-3-270m-it-int8.task` + `gemma-3-270m-it-int8.litertlm`
-
-### iOS (Limited Support ⚠️)
-- **Recommended**: Use Apple Intelligence (built-in, no download needed)
-- **Alternative (Experimental)**: 
-  - **Model**: Gemma-2 2B (documented as compatible but may still fail)
-  - **Format**: `.task` files (`.bin` format preferred but not available)
-  - **Where to download**:
-    - [Hugging Face MediaPipe models](https://huggingface.co/collections/google/mediapipe-668392ead2d6768e82fb3b87) 
-    - Look for `Gemma2-2B-IT_*_ekv*.task` files
-    - Example: `Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280.task`
-  - **Note**: Even with Gemma-2 2B, you may still encounter errors. Apple Intelligence is more reliable.
-
-### Web
-- **Model**: Gemma-3 models
-- **Format**: `.task` files
-- **Where to download**: Same as Android
-
-## Download Instructions
-
-1. **For Android**:
-   - Go to [Kaggle Gemma models](https://www.kaggle.com/models/google/gemma)
-   - Click "LiteRT (formerly TFLite)" tab
-   - Download both `.task` and `.litertlm` files
-   - Place in `android/app/src/main/assets/`
-
-2. **For iOS** (if not using Apple Intelligence):
-   - Visit [Hugging Face MediaPipe collection](https://huggingface.co/collections/google/mediapipe-668392ead2d6768e82fb3b87)
-   - Find Gemma-2 2B models
-   - Download `.task` files (and `.litertlm` if available)
-   - Add to Xcode project in "Copy Bundle Resources"
-   - Note: Success is not guaranteed due to format compatibility issues
-
-3. **Set the model path**:
-
-```typescript
+```ts
 import { CapgoLLM } from '@capgo/capacitor-llm';
 
-// iOS - Use Apple Intelligence (default)
 await CapgoLLM.setModel({ path: 'Apple Intelligence' });
-
-// iOS - Use MediaPipe model (experimental)
-await CapgoLLM.setModel({ 
-  path: 'Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280',
-  modelType: 'task',
-  maxTokens: 1280
-});
-
-// Now you can create chats and send messages
 const chat = await CapgoLLM.createChat();
 ```
 
 ### Android
 
-For Android, you need to include a compatible LLM model in your app. The plugin uses MediaPipe's tasks-genai, which supports various model formats.
+Recommended path:
 
-When Gemini mini will be out of close alpha we might add it as default like we do Apple intelligence default
-https://developer.android.com/ai/gemini-nano/experimental
+- Use LiteRT-LM `.litertlm` bundles
+- Gemma 4 E2B and E4B are good default examples
+- Models are available from the public [`litert-community`](https://huggingface.co/litert-community) Hugging Face repos
 
-**Important:** Your app's `minSdkVersion` must be set to 24 or higher. Update your `android/variables.gradle` file:
-```gradle
-ext {
-    minSdkVersion = 24
-    // ... other settings
-}
-```
+Quickstart with a downloaded Gemma 4 model:
 
-1. **Download a compatible model**: 
-   
-   **For Android: Gemma 3 Models** (Working ✅)
-   - **Recommended**: Gemma 3 270M - Smallest, most efficient (~240-400MB)
-   - Text-only model optimized for on-device inference
-   - Download from [Kaggle](https://www.kaggle.com/models/google/gemma) → "LiteRT (formerly TFLite)" tab
-   - Get both `.task` and `.litertlm` files
-   
-   **For iOS: Limited Options** (⚠️)
-   - **Option 1** (Recommended): Use Apple Intelligence - no download needed
-   - **Option 2** (Experimental): Try Gemma-2 2B from [Hugging Face](https://huggingface.co/collections/google/mediapipe-668392ead2d6768e82fb3b87)
-     - Download `Gemma2-2B-IT_*.task` files  
-     - May still encounter compatibility errors
-   
-   **Available Model Sizes** (from [Google AI](https://ai.google.dev/gemma/docs/core#sizes)):
-   - `gemma-3-270m` - Most portable, text-only (~240-400MB) - Android only
-   - `gemma-3-1b` - Larger text-only (~892MB-1.5GB) - Android only
-   - `gemma-2-2b` - Cross-platform compatible (~1-2GB) - iOS experimental
-   - Larger models available but not recommended for mobile
-   
-   For automated download, see the script in the example app section below.
-
-2. **Add the model to your app**:
-   
-   **Option A - Bundle in APK (for smaller models)**:
-   - Place the model files in your app's `android/app/src/main/assets/` directory
-   - The `/android_asset/` prefix is used to reference files from the assets folder
-   - Note: This approach may increase APK size significantly
-   
-   **Option B - Download at runtime (recommended for production)**:
-   - Host the model files on a server
-   - Download them to your app's files directory at runtime
-   - This keeps your APK size small
-
-3. **Set the model path**:
-
-```typescript
+```ts
 import { CapgoLLM } from '@capgo/capacitor-llm';
 
-// If model is in assets folder (recommended) - point to the .task file
-await CapgoLLM.setModelPath({ path: '/android_asset/gemma-3-270m-it-int8.task' });
+const result = await CapgoLLM.downloadModel({
+  url: 'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm?download=true',
+  filename: 'gemma-4-E2B-it.litertlm',
+});
 
-// If model is in app's files directory
-await CapgoLLM.setModelPath({ path: '/data/data/com.yourapp/files/gemma-3-270m-it-int8.task' });
+await CapgoLLM.setModel({
+  path: result.path,
+  modelType: 'litertlm',
+  maxTokens: 4096,
+  topk: 40,
+  temperature: 0.8,
+});
 
-// Example: Download model at runtime (recommended for production)
-async function downloadModel() {
-  // Add progress listener
-  await CapgoLLM.addListener('downloadProgress', (event) => {
-    console.log(`Download progress: ${event.progress}%`);
-  });
-
-  // Download the model
-  const result = await CapgoLLM.downloadModel({
-    url: 'https://your-server.com/models/gemma-3-270m-it-int8.task',
-    companionUrl: 'https://your-server.com/models/gemma-3-270m-it-int8.litertlm', // Android only
-    filename: 'gemma-3-270m-it-int8.task' // Optional, defaults to filename from URL
-  });
-
-  console.log('Model downloaded to:', result.path);
-  if (result.companionPath) {
-    console.log('Companion file downloaded to:', result.companionPath);
-  }
-
-  // Now set the model path
-  await CapgoLLM.setModelPath({ path: result.path });
-}
-
-// Now you can create chats and send messages
 const chat = await CapgoLLM.createChat();
 ```
 
-## Usage Example
+Bundled asset example:
 
-```typescript
+```ts
+await CapgoLLM.setModel({
+  path: '/android_asset/gemma-4-E2B-it.litertlm',
+  modelType: 'litertlm',
+  maxTokens: 4096,
+});
+```
+
+Legacy compatibility:
+
+- Existing Android `.task` models still load through the compatibility path
+- New integrations should prefer `.litertlm`
+
+### Web
+
+The web implementation still uses MediaPipe `.task` models.
+
+Example:
+
+```ts
+await CapgoLLM.setModel({
+  path: '/models/gemma-4-E2B-it-web.task',
+  modelType: 'task',
+  maxTokens: 4096,
+});
+```
+
+## Usage
+
+```ts
 import { CapgoLLM } from '@capgo/capacitor-llm';
 
-// Check if LLM is ready
 const { readiness } = await CapgoLLM.getReadiness();
 console.log('LLM readiness:', readiness);
 
-// Set a custom model (optional - uses system default if not called)
-// iOS: Use a GGUF model from bundle or path
-// Android: Use a MediaPipe model from assets or files
-await CapgoLLM.setModelPath({ 
-  path: Platform.isIOS ? 'gemma-3-270m.gguf' : '/android_asset/gemma-3-270m-it-int8.task' 
+const { id } = await CapgoLLM.createChat();
+
+await CapgoLLM.addListener('textFromAi', (event) => {
+  console.log('chunk', event.text);
 });
 
-// Create a chat session
-const { id: chatId } = await CapgoLLM.createChat();
-
-// Listen for AI responses
-CapgoLLM.addListener('textFromAi', (event) => {
-  console.log('AI:', event.text);
+await CapgoLLM.addListener('aiFinished', ({ chatId }) => {
+  console.log('finished', chatId);
 });
 
-// Listen for completion
-CapgoLLM.addListener('aiFinished', (event) => {
-  console.log('AI finished responding to chat:', event.chatId);
-});
-
-// Send a message
 await CapgoLLM.sendMessage({
-  chatId,
-  message: 'Hello! How are you today?'
+  chatId: id,
+  message: 'Explain why local inference is useful on mobile.',
 });
 ```
+
+## Notes
+
+- Android now prefers LiteRT-LM and Gemma 4 style `.litertlm` bundles.
+- Web is unchanged and continues to rely on MediaPipe.
+- iOS custom-model support remains available through the existing MediaPipe path, but Apple Intelligence is the preferred default where available.
 
 ## API
 
@@ -355,8 +226,9 @@ setModel(options: ModelOptions) => Promise<void>
 ```
 
 Sets the model configuration
-- iOS: Use "Apple Intelligence" as path for system model, or provide path to MediaPipe model
-- Android: Path to a MediaPipe model file (in assets or files directory)
+- iOS: Use "Apple Intelligence" as path for the system model, or provide a MediaPipe custom model
+- Android: Prefer LiteRT-LM `.litertlm` bundles; legacy MediaPipe `.task` models are still supported
+- Web: Provide a MediaPipe `.task` model
 
 | Param         | Type                                                  | Description               |
 | ------------- | ----------------------------------------------------- | ------------------------- |
@@ -478,14 +350,14 @@ Get the native Capacitor plugin version.
 
 Model configuration options
 
-| Prop              | Type                | Description                                                                                                |
-| ----------------- | ------------------- | ---------------------------------------------------------------------------------------------------------- |
-| **`path`**        | <code>string</code> | Model path or "Apple Intelligence" for iOS system model                                                    |
-| **`modelType`**   | <code>string</code> | Model file type/extension (e.g., "task", "bin", "litertlm"). If not provided, will be extracted from path. |
-| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                 |
-| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                          |
-| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                               |
-| **`randomSeed`**  | <code>number</code> | Random seed for generation                                                                                 |
+| Prop              | Type                | Description                                                                                                           |
+| ----------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **`path`**        | <code>string</code> | Model path or "Apple Intelligence" for the iOS system model                                                           |
+| **`modelType`**   | <code>string</code> | Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. |
+| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                            |
+| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                                     |
+| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                                          |
+| **`randomSeed`**  | <code>number</code> | Random seed for generation                                                                                            |
 
 
 #### DownloadModelResult
@@ -502,11 +374,11 @@ Result of model download
 
 Options for downloading a model
 
-| Prop               | Type                | Description                                                   |
-| ------------------ | ------------------- | ------------------------------------------------------------- |
-| **`url`**          | <code>string</code> | URL of the model file to download                             |
-| **`companionUrl`** | <code>string</code> | Optional: URL of companion file (e.g., .litertlm for Android) |
-| **`filename`**     | <code>string</code> | Optional: Custom filename (defaults to filename from URL)     |
+| Prop               | Type                | Description                                                |
+| ------------------ | ------------------- | ---------------------------------------------------------- |
+| **`url`**          | <code>string</code> | URL of the model file to download                          |
+| **`companionUrl`** | <code>string</code> | Optional: URL of a companion file for legacy model formats |
+| **`filename`**     | <code>string</code> | Optional: Custom filename (defaults to filename from URL)  |
 
 
 #### TextFromAiEvent
@@ -550,94 +422,11 @@ Event data for readiness status changes
 
 </docgen-api>
 
-## Example App Model Setup
+## Example App
 
-The example app demonstrates how to use custom models with the Capacitor LLM plugin.
+The repo includes an `example-app/` that demonstrates:
 
-### Downloading Models
+- Apple Intelligence on iOS
+- Gemma 4 LiteRT-LM model downloads on Android
 
-Since AI models require license acceptance, you need to download them manually:
-
-### Model Setup by Platform
-
-#### Android Setup (Gemma 3 270M) ✅
-
-1. **Create Kaggle account and accept license:**
-   - Create a [Kaggle account](https://www.kaggle.com)
-   - Visit [Gemma 3 models](https://www.kaggle.com/models/google/gemma-3) and accept terms
-
-2. **Download the model:**
-   - Click "LiteRT (formerly TFLite)" tab
-   - Download `gemma-3-270m-it-int8` (get BOTH files):
-     - `gemma-3-270m-it-int8.task`
-     - `gemma-3-270m-it-int8.litertlm`
-
-3. **Place in Android app:**
-   - Copy BOTH files to: `example-app/android/app/src/main/assets/`
-   - In code, reference with `/android_asset/` prefix
-
-#### iOS Setup ⚠️
-
-**Option 1 (Recommended)**: Use Apple Intelligence
-- No model download needed
-- Works out of the box on iOS 26.0+
-
-**Option 2 (Experimental)**: Try Gemma-2 2B
-1. Visit [Hugging Face MediaPipe models](https://huggingface.co/collections/google/mediapipe-668392ead2d6768e82fb3b87)
-2. Download Gemma-2 2B files (e.g., `Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280.task`)
-3. Add to Xcode project in "Copy Bundle Resources"
-4. Note: May still encounter errors - Apple Intelligence is more reliable
-### Update your code to use the model:
-```typescript
-// Android - Gemma 3 270M
-await CapgoLLM.setModel({ 
-  path: '/android_asset/gemma-3-270m-it-int8.task',
-  maxTokens: 2048,
-  topk: 40,
-  temperature: 0.8
-});
-
-// iOS Option 1 - Apple Intelligence (Recommended)
-await CapgoLLM.setModel({ 
-  path: 'Apple Intelligence' 
-});
-
-// iOS Option 2 - Gemma-2 2B (Experimental)
-await CapgoLLM.setModel({ 
-  path: 'Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280',
-  modelType: 'task',
-  maxTokens: 1280,
-  topk: 40,
-  temperature: 0.8
-});
-```
-
-### Model Selection Guide
-
-**For Android**: Gemma 3 270M is recommended because:
-- Smallest size (~240-400MB)
-- Text-only (perfect for chat)
-- Optimized for mobile devices
-- Works reliably with MediaPipe
-
-**For iOS**: Apple Intelligence is recommended because:
-- No download required
-- Native iOS integration
-- Better performance
-- No compatibility issues
-
-## Known Issues
-
-- **iOS MediaPipe Compatibility**: MediaPipe iOS SDK has issues with `.task` format models
-  - Symptom: `(prefill_input_names.size() % 2)==(0)` errors
-  - Solution: Use Apple Intelligence (built-in) instead of custom models
-  - Alternative: Try Gemma-2 2B models (experimental, may still fail)
-
-- **Platform Requirements**:
-  - iOS: Apple Intelligence requires iOS 26.0+
-  - Android: Minimum SDK 24
-
-- **Performance Considerations**:
-  - Model files are large (300MB-2GB)
-  - Initial download takes time
-  - Some devices may have memory limitations
+See [example-app/README.md](./example-app/README.md) for local setup instructions.

--- a/README.md
+++ b/README.md
@@ -368,15 +368,16 @@ Get the native Capacitor plugin version.
 #### ModelOptions
 
 Model configuration options
+Only `path` is required. All other properties are optional overrides.
 
-| Prop              | Type                | Description                                                                                                           |
-| ----------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **`path`**        | <code>string</code> | Model path or "Apple Intelligence" for the iOS system model                                                           |
-| **`modelType`**   | <code>string</code> | Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. |
-| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                            |
-| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                                     |
-| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                                          |
-| **`randomSeed`**  | <code>number</code> | Random seed for generation                                                                                            |
+| Prop              | Type                | Description                                                                                                                     |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **`path`**        | <code>string</code> | Model path or "Apple Intelligence" for the Apple system model on iOS                                                            |
+| **`modelType`**   | <code>string</code> | Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. |
+| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                                      |
+| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                                               |
+| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                                                    |
+| **`randomSeed`**  | <code>number</code> | Optional. Random seed for generation.                                                                                           |
 
 
 #### DownloadModelResult
@@ -392,6 +393,7 @@ Result of model download
 #### DownloadModelOptions
 
 Options for downloading a model
+Only `url` is required. `companionUrl` and `filename` are optional.
 
 | Prop               | Type                | Description                                                |
 | ------------------ | ------------------- | ---------------------------------------------------------- |
@@ -423,11 +425,12 @@ Event data for AI completion
 #### GenerationErrorEvent
 
 Event data for generation failures
+`chatId` is optional and may be omitted when the failure is not tied to a specific chat.
 
-| Prop         | Type                | Description                                     |
-| ------------ | ------------------- | ----------------------------------------------- |
-| **`chatId`** | <code>string</code> | The chat session ID that failed, when available |
-| **`error`**  | <code>string</code> | Error message describing the failure            |
+| Prop         | Type                | Description                                                |
+| ------------ | ------------------- | ---------------------------------------------------------- |
+| **`chatId`** | <code>string</code> | Optional. The chat session ID that failed, when available. |
+| **`error`**  | <code>string</code> | Error message describing the failure                       |
 
 
 #### DownloadProgressEvent

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ On-device LLM support for Capacitor.
 
 Current platform strategy:
 
-- iOS: Apple Intelligence by default, plus legacy custom MediaPipe models
+- iOS: Apple Intelligence by default, plus downloadable Gemma 4 `.litertlm` custom models
 - Android: LiteRT-LM for `.litertlm` bundles, with a compatibility fallback for legacy MediaPipe `.task` models
-- Web: MediaPipe `@mediapipe/tasks-genai`
+- Web: Gemma 4 web models through `@mediapipe/tasks-genai`
 
 ## Documentation
 
@@ -33,14 +33,14 @@ The most complete plugin docs are available at [capgo.app/docs/plugins/llm](http
 ## Installation
 
 ```bash
-npm install @capgo/capacitor-llm
-npx cap sync
+bun add @capgo/capacitor-llm
+bunx cap sync
 ```
 
 If you use the web implementation, also install the MediaPipe peer dependency:
 
 ```bash
-npm install @mediapipe/tasks-genai
+bun add @mediapipe/tasks-genai
 ```
 
 ## Model Setup
@@ -54,9 +54,9 @@ Recommended path:
 
 Custom iOS model path:
 
-- Still uses the existing MediaPipe integration
+- Uses the current GenAI session-based custom-model path
 - Requires CocoaPods for `MediaPipeTasksGenAI`
-- Best treated as experimental compared with Apple Intelligence
+- Supports downloaded mobile Gemma 4 `.litertlm` bundles
 
 Example:
 
@@ -113,13 +113,15 @@ Legacy compatibility:
 
 ### Web
 
-The web implementation still uses MediaPipe `.task` models.
+The web implementation uses `@mediapipe/tasks-genai` with web-ready model artifacts.
+
+Gemma 4 web models are published next to the mobile LiteRT-LM bundles and use `*-web.task`.
 
 Example:
 
 ```ts
 await CapgoLLM.setModel({
-  path: '/models/gemma-4-E2B-it-web.task',
+  path: 'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.task?download=true',
   modelType: 'task',
   maxTokens: 4096,
 });
@@ -152,8 +154,9 @@ await CapgoLLM.sendMessage({
 ## Notes
 
 - Android now prefers LiteRT-LM and Gemma 4 style `.litertlm` bundles.
-- Web is unchanged and continues to rely on MediaPipe.
-- iOS custom-model support remains available through the existing MediaPipe path, but Apple Intelligence is the preferred default where available.
+- iOS custom-model support now uses per-chat GenAI sessions and can load downloaded Gemma 4 `.litertlm` bundles.
+- Web uses Gemma 4 `*-web.task` artifacts through `@mediapipe/tasks-genai`.
+- Apple Intelligence remains the preferred default on iOS where available.
 
 ## API
 
@@ -227,9 +230,9 @@ setModel(options: ModelOptions) => Promise<void>
 ```
 
 Sets the model configuration
-- iOS: Use "Apple Intelligence" as path for the system model, or provide a MediaPipe custom model
+- iOS: Use "Apple Intelligence" as path for the system model, or provide a downloaded custom model bundle such as Gemma 4 `.litertlm`
 - Android: Prefer LiteRT-LM `.litertlm` bundles; legacy MediaPipe `.task` models are still supported
-- Web: Provide a MediaPipe `.task` model
+- Web: Provide a web-ready model asset for `@mediapipe/tasks-genai` such as Gemma 4 `*-web.task`
 
 | Param         | Type                                                  | Description               |
 | ------------- | ----------------------------------------------------- | ------------------------- |
@@ -370,14 +373,14 @@ Get the native Capacitor plugin version.
 Model configuration options
 Only `path` is required. All other properties are optional overrides.
 
-| Prop              | Type                | Description                                                                                                                     |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| **`path`**        | <code>string</code> | Model path or "Apple Intelligence" for the Apple system model on iOS                                                            |
-| **`modelType`**   | <code>string</code> | Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. |
-| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                                      |
-| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                                               |
-| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                                                    |
-| **`randomSeed`**  | <code>number</code> | Optional. Random seed for generation.                                                                                           |
+| Prop              | Type                | Description                                                                                                                               |
+| ----------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **`path`**        | <code>string</code> | Model path or "Apple Intelligence" for the Apple system model on iOS. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. |
+| **`modelType`**   | <code>string</code> | Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path.           |
+| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                                                |
+| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                                                         |
+| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                                                              |
+| **`randomSeed`**  | <code>number</code> | Optional. Random seed for generation.                                                                                                     |
 
 
 #### DownloadModelResult

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ await CapgoLLM.sendMessage({
 * [`downloadModel(...)`](#downloadmodel)
 * [`addListener('textFromAi', ...)`](#addlistenertextfromai-)
 * [`addListener('aiFinished', ...)`](#addlisteneraifinished-)
+* [`addListener('generationError', ...)`](#addlistenergenerationerror-)
 * [`addListener('downloadProgress', ...)`](#addlistenerdownloadprogress-)
 * [`addListener('readinessChange', ...)`](#addlistenerreadinesschange-)
 * [`getPluginVersion()`](#getpluginversion)
@@ -292,6 +293,24 @@ Adds a listener for AI completion events
 --------------------
 
 
+### addListener('generationError', ...)
+
+```typescript
+addListener(eventName: 'generationError', listenerFunc: (event: GenerationErrorEvent) => void) => Promise<{ remove: () => Promise<void>; }>
+```
+
+Adds a listener for generation failures that happen after streaming starts
+
+| Param              | Type                                                                                      | Description                               |
+| ------------------ | ----------------------------------------------------------------------------------------- | ----------------------------------------- |
+| **`eventName`**    | <code>'generationError'</code>                                                            | - Event name 'generationError'            |
+| **`listenerFunc`** | <code>(event: <a href="#generationerrorevent">GenerationErrorEvent</a>) =&gt; void</code> | - Callback function for generation errors |
+
+**Returns:** <code>Promise&lt;{ remove: () =&gt; Promise&lt;void&gt;; }&gt;</code>
+
+--------------------
+
+
 ### addListener('downloadProgress', ...)
 
 ```typescript
@@ -399,6 +418,16 @@ Event data for AI completion
 | Prop         | Type                | Description                       |
 | ------------ | ------------------- | --------------------------------- |
 | **`chatId`** | <code>string</code> | The chat session ID that finished |
+
+
+#### GenerationErrorEvent
+
+Event data for generation failures
+
+| Prop         | Type                | Description                                     |
+| ------------ | ------------------- | ----------------------------------------------- |
+| **`chatId`** | <code>string</code> | The chat session ID that failed, when available |
+| **`error`**  | <code>string</code> | Error message describing the failure            |
 
 
 #### DownloadProgressEvent

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation 'com.google.ai.edge.litertlm:litertlm-android:0.10.0'
     implementation 'com.google.mediapipe:tasks-genai:0.10.24'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/src/main/java/ee/forgr/capgo_llm/LLM.java
+++ b/android/src/main/java/ee/forgr/capgo_llm/LLM.java
@@ -1,8 +1,20 @@
 package ee.forgr.capgo_llm;
 
 import android.content.Context;
+import com.google.ai.edge.litertlm.Backend;
+import com.google.ai.edge.litertlm.Content;
+import com.google.ai.edge.litertlm.Conversation;
+import com.google.ai.edge.litertlm.ConversationConfig;
+import com.google.ai.edge.litertlm.Engine;
+import com.google.ai.edge.litertlm.EngineConfig;
+import com.google.ai.edge.litertlm.Message;
+import com.google.ai.edge.litertlm.SamplerConfig;
 import com.google.mediapipe.tasks.genai.llminference.LlmInference;
 import com.google.mediapipe.tasks.genai.llminference.LlmInference.LlmInferenceOptions;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -11,13 +23,29 @@ import java.util.concurrent.Executors;
 
 public class LLM {
 
+    private enum BackendType {
+        LITERT,
+        MEDIAPIPE
+    }
+
+    private static final double DEFAULT_TOP_P = 0.95d;
     private static LLM instance;
+
+    private final Context context;
+    private final Executor executor;
+    private final Map<String, ChatSession> chatSessions;
+
+    private Engine engine;
     private LlmInference llmInference;
-    private Map<String, ChatSession> chatSessions;
     private boolean isReady = false;
-    private Context context;
-    private Executor executor;
     private String modelPath = null;
+    private String modelType = null;
+    private BackendType activeBackend = BackendType.LITERT;
+
+    private Integer maxTokens = 2048;
+    private Integer topk = 40;
+    private Float temperature = 0.1f;
+    private Integer randomSeed = 101;
 
     private LLM(Context context) {
         this.context = context;
@@ -32,26 +60,36 @@ public class LLM {
         return instance;
     }
 
-    // Model parameters
-    private Integer maxTokens = 2048;
-    private Integer topk = 40;
-    private Float temperature = 0.1f;
-
-    public void setModel(String path, Integer maxTokens, Integer topk, Float temperature, ModelLoadCallback callback) {
+    public void setModel(
+        String path,
+        String modelType,
+        Integer maxTokens,
+        Integer topk,
+        Float temperature,
+        Integer randomSeed,
+        ModelLoadCallback callback
+    ) {
         this.modelPath = path;
+        this.modelType = modelType;
         this.maxTokens = maxTokens;
         this.topk = topk;
         this.temperature = temperature;
-        isReady = false;
+        this.randomSeed = randomSeed;
 
-        // If LLM was already initialized, clean it up
-        if (llmInference != null) {
-            llmInference = null;
-        }
+        resetModelState();
 
         android.util.Log.d(
             "LLM",
-            "setModel called with path: " + path + ", maxTokens: " + maxTokens + ", topk: " + topk + ", temperature: " + temperature
+            "setModel called with path: " +
+                path +
+                ", modelType: " +
+                modelType +
+                ", maxTokens: " +
+                maxTokens +
+                ", topk: " +
+                topk +
+                ", temperature: " +
+                temperature
         );
         initializeModel(callback);
     }
@@ -66,120 +104,223 @@ public class LLM {
 
         executor.execute(() -> {
             try {
-                String actualPath = modelPath;
+                activeBackend = resolveBackend(modelPath, modelType);
+                String actualPath = resolveModelPath(modelPath, activeBackend);
 
-                // Debug logging
-                android.util.Log.d("LLM", "Original model path: " + modelPath);
+                android.util.Log.d("LLM", "Resolved model path: " + actualPath + " using backend: " + activeBackend);
 
-                // For /android_asset/ paths, we need to handle them specially
-                if (modelPath.startsWith("/android_asset/")) {
-                    // Extract the relative path from assets
-                    String assetPath = modelPath.substring("/android_asset/".length());
-                    android.util.Log.d("LLM", "Asset path: " + assetPath);
-
-                    // Check if the asset exists
-                    try {
-                        java.io.InputStream is = context.getAssets().open(assetPath);
-                        is.close();
-                        android.util.Log.d("LLM", "Asset exists: " + assetPath);
-
-                        // For MediaPipe, we need to copy the asset to a file
-                        java.io.File cacheDir = context.getCacheDir();
-                        java.io.File modelFile = new java.io.File(cacheDir, assetPath);
-
-                        // Create parent directories if needed
-                        modelFile.getParentFile().mkdirs();
-
-                        // Copy asset to cache
-                        copyAssetToFile(assetPath, modelFile);
-                        actualPath = modelFile.getAbsolutePath();
-                        android.util.Log.d("LLM", "Copied asset to: " + actualPath);
-
-                        // Also check for companion .litertlm file
-                        String litertlmPath = assetPath.replace(".task", ".litertlm");
-                        try {
-                            java.io.InputStream litertlmIs = context.getAssets().open(litertlmPath);
-                            litertlmIs.close();
-                            java.io.File litertlmFile = new java.io.File(cacheDir, litertlmPath);
-                            copyAssetToFile(litertlmPath, litertlmFile);
-                            android.util.Log.d("LLM", "Also copied companion file: " + litertlmFile.getAbsolutePath());
-                        } catch (Exception e) {
-                            android.util.Log.d("LLM", "No companion .litertlm file found");
-                        }
-                    } catch (Exception e) {
-                        android.util.Log.e("LLM", "Asset not found: " + assetPath, e);
-                        throw new RuntimeException("Asset not found: " + assetPath);
-                    }
+                if (activeBackend == BackendType.LITERT) {
+                    initializeLiteRtModel(actualPath);
+                } else {
+                    initializeMediaPipeModel(actualPath);
                 }
 
-                android.util.Log.d("LLM", "Final model path: " + actualPath);
-
-                // Create options for LLM inference
-                LlmInferenceOptions.Builder optionsBuilder = LlmInferenceOptions.builder()
-                    .setModelPath(actualPath)
-                    .setMaxTokens(maxTokens)
-                    .setMaxTopK(topk);
-
-                LlmInferenceOptions options = optionsBuilder.build();
-
-                // Initialize the LLM inference
-                llmInference = LlmInference.createFromOptions(context, options);
                 isReady = true;
 
                 if (callback != null) {
                     callback.onSuccess();
                 }
-            } catch (Exception e) {
-                isReady = false;
-                e.printStackTrace();
+            } catch (Exception exception) {
+                android.util.Log.e("LLM", "Failed to initialize model", exception);
+                resetModelState();
+
                 if (callback != null) {
-                    callback.onError(e.getMessage());
+                    callback.onError(exception.getMessage());
                 }
             }
         });
     }
 
-    private void copyAssetToFile(String assetPath, java.io.File destFile) throws Exception {
-        java.io.InputStream is = context.getAssets().open(assetPath);
-        java.io.FileOutputStream fos = new java.io.FileOutputStream(destFile);
-        byte[] buffer = new byte[1024];
-        int length;
-        while ((length = is.read(buffer)) > 0) {
-            fos.write(buffer, 0, length);
+    private void initializeLiteRtModel(String actualPath) {
+        EngineConfig config = new EngineConfig(
+            actualPath,
+            new Backend.CPU(),
+            new Backend.CPU(),
+            new Backend.CPU(),
+            maxTokens,
+            context.getCacheDir().getAbsolutePath()
+        );
+        engine = new Engine(config);
+        engine.initialize();
+    }
+
+    private void initializeMediaPipeModel(String actualPath) {
+        LlmInferenceOptions options = LlmInferenceOptions.builder()
+            .setModelPath(actualPath)
+            .setMaxTokens(maxTokens)
+            .setMaxTopK(topk)
+            .build();
+        llmInference = LlmInference.createFromOptions(context, options);
+    }
+
+    private BackendType resolveBackend(String path, String modelType) {
+        return "litertlm".equals(normalizeModelType(path, modelType)) ? BackendType.LITERT : BackendType.MEDIAPIPE;
+    }
+
+    private String normalizeModelType(String path, String modelType) {
+        if (modelType != null && !modelType.isBlank()) {
+            return modelType.toLowerCase();
         }
-        fos.close();
-        is.close();
+
+        int extensionIndex = path.lastIndexOf('.');
+        if (extensionIndex == -1 || extensionIndex == path.length() - 1) {
+            return "";
+        }
+
+        return path.substring(extensionIndex + 1).toLowerCase();
+    }
+
+    private String resolveModelPath(String path, BackendType backendType) throws Exception {
+        if (!path.startsWith("/android_asset/")) {
+            return path;
+        }
+
+        String assetPath = path.substring("/android_asset/".length());
+        File cacheDir = context.getCacheDir();
+        File modelFile = new File(cacheDir, assetPath);
+
+        copyAssetToFile(assetPath, modelFile);
+
+        if (backendType == BackendType.MEDIAPIPE && assetPath.endsWith(".task")) {
+            String companionPath = assetPath.replace(".task", ".litertlm");
+            try {
+                copyAssetToFile(companionPath, new File(cacheDir, companionPath));
+            } catch (Exception exception) {
+                android.util.Log.d("LLM", "No MediaPipe companion file found for " + assetPath);
+            }
+        }
+
+        return modelFile.getAbsolutePath();
+    }
+
+    private void copyAssetToFile(String assetPath, File destination) throws Exception {
+        File parent = destination.getParentFile();
+        if (parent != null && !parent.exists()) {
+            parent.mkdirs();
+        }
+
+        try (
+            InputStream inputStream = context.getAssets().open(assetPath);
+            FileOutputStream outputStream = new FileOutputStream(destination)
+        ) {
+            byte[] buffer = new byte[8192];
+            int length;
+            while ((length = inputStream.read(buffer)) > 0) {
+                outputStream.write(buffer, 0, length);
+            }
+        }
     }
 
     public String createChat() {
+        if (!isReady) {
+            throw new IllegalStateException("Model not ready");
+        }
+
         String chatId = UUID.randomUUID().toString();
-        ChatSession session = new ChatSession();
+        ChatSession session;
+
+        if (activeBackend == BackendType.LITERT) {
+            if (engine == null) {
+                throw new IllegalStateException("LiteRT-LM engine not initialized");
+            }
+            session = ChatSession.forLiteRt(createLiteRtConversation());
+        } else {
+            if (llmInference == null) {
+                throw new IllegalStateException("MediaPipe model not initialized");
+            }
+            session = ChatSession.forMediaPipe();
+        }
+
         chatSessions.put(chatId, session);
         return chatId;
+    }
+
+    private Conversation createLiteRtConversation() {
+        ConversationConfig defaults = new ConversationConfig();
+        SamplerConfig samplerConfig = new SamplerConfig(topk, DEFAULT_TOP_P, temperature.doubleValue(), randomSeed);
+        ConversationConfig config = defaults.copy(
+            defaults.getSystemInstruction(),
+            defaults.getInitialMessages(),
+            defaults.getTools(),
+            samplerConfig,
+            defaults.getAutomaticToolCalling(),
+            defaults.getChannels()
+        );
+        return engine.createConversation(config);
     }
 
     public void sendMessage(String chatId, String message, MessageCallback callback) {
         ChatSession session = chatSessions.get(chatId);
         if (session == null) {
-            callback.onError("Chat session not found");
+            throw new IllegalStateException("Chat session not found");
+        }
+
+        if (!isReady) {
+            throw new IllegalStateException("Model not ready");
+        }
+
+        if (session.backendType == BackendType.LITERT) {
+            sendMessageWithLiteRt(chatId, message, session, callback);
             return;
         }
 
-        if (!isReady || llmInference == null) {
-            callback.onError("Model not ready");
-            return;
+        if (llmInference == null) {
+            throw new IllegalStateException("MediaPipe model not ready");
         }
 
+        sendMessageWithMediaPipe(chatId, message, session, callback);
+    }
+
+    private void sendMessageWithLiteRt(String chatId, String message, ChatSession session, MessageCallback callback) {
+        if (session.conversation == null) {
+            throw new IllegalStateException("LiteRT-LM conversation not found");
+        }
+
+        session.conversation.sendMessageAsync(
+            message,
+            new com.google.ai.edge.litertlm.MessageCallback() {
+                @Override
+                public void onMessage(Message responseMessage) {
+                    String chunk = extractText(responseMessage);
+                    if (!chunk.isEmpty()) {
+                        callback.onTextReceived(chatId, chunk, true);
+                    }
+                }
+
+                @Override
+                public void onDone() {
+                    callback.onComplete(chatId);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {
+                    callback.onError(throwable.getMessage());
+                }
+            },
+            Collections.emptyMap()
+        );
+    }
+
+    private String extractText(Message responseMessage) {
+        StringBuilder builder = new StringBuilder();
+
+        for (Content content : responseMessage.getContents().getContents()) {
+            if (content instanceof Content.Text) {
+                builder.append(((Content.Text) content).getText());
+            }
+        }
+
+        return builder.toString();
+    }
+
+    private void sendMessageWithMediaPipe(String chatId, String message, ChatSession session, MessageCallback callback) {
         executor.execute(() -> {
             try {
-                // Add user message to history
                 session.addMessage("user", message);
 
-                // Build the full prompt with chat history
                 String fullPrompt = session.buildPrompt(message);
                 android.util.Log.d("LLM", "Full prompt: " + fullPrompt);
 
-                // Create a session with proper options
                 com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession.LlmInferenceSessionOptions sessionOptions =
                     com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession.LlmInferenceSessionOptions.builder()
                         .setTopK(topk)
@@ -189,10 +330,8 @@ public class LLM {
                 com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession inferenceSession =
                     com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession.createFromOptions(llmInference, sessionOptions);
 
-                // Add the query
                 inferenceSession.addQueryChunk(fullPrompt);
 
-                // Use streaming API
                 final StringBuilder fullResponse = new StringBuilder();
 
                 com.google.mediapipe.tasks.genai.llminference.ProgressListener<String> resultListener =
@@ -204,22 +343,16 @@ public class LLM {
                         public void run(String partialResult, boolean done) {
                             android.util.Log.d("LLM", "Partial result: " + partialResult + ", done: " + done);
 
-                            // Accumulate in buffer
                             buffer.append(partialResult);
 
-                            // Process buffer when we have enough content or when done
                             String content = buffer.toString();
-
-                            // Check if we can process some content
                             StringBuilder toSend = new StringBuilder();
                             int i = 0;
                             while (i < content.length()) {
-                                // Check for escape sequence
                                 if (i < content.length() - 1 && content.charAt(i) == '\\' && content.charAt(i + 1) == 'n') {
                                     toSend.append('\n');
                                     i += 2;
                                 } else if (i == content.length() - 1 && content.charAt(i) == '\\' && !done) {
-                                    // We have a backslash at the end and more chunks coming - wait for next chunk
                                     break;
                                 } else {
                                     toSend.append(content.charAt(i));
@@ -227,14 +360,11 @@ public class LLM {
                                 }
                             }
 
-                            // Update buffer to contain only unprocessed content
                             buffer = new StringBuilder(content.substring(i));
 
-                            // Send processed content if any
                             String chunk = toSend.toString();
 
-                            // Remove leading newline from the very first content
-                            if (!hasStarted && chunk.length() > 0) {
+                            if (!hasStarted && !chunk.isEmpty()) {
                                 chunk = chunk.replaceFirst("^\\n", "");
                                 hasStarted = true;
                             }
@@ -244,37 +374,66 @@ public class LLM {
                                 fullResponse.append(chunk);
                             }
 
-                            // Process any remaining content when done
                             if (done && buffer.length() > 0) {
                                 String remaining = buffer.toString();
                                 if (!remaining.isEmpty()) {
                                     callback.onTextReceived(chatId, remaining, true);
                                     fullResponse.append(remaining);
                                 }
+                            }
 
-                                // Add complete response to history
+                            if (done) {
                                 session.addMessage("assistant", fullResponse.toString());
                                 callback.onComplete(chatId);
 
-                                // Close the session
                                 try {
                                     inferenceSession.close();
-                                } catch (Exception e) {
-                                    android.util.Log.e("LLM", "Failed to close session: " + e.getMessage());
+                                } catch (Exception exception) {
+                                    android.util.Log.e("LLM", "Failed to close MediaPipe session", exception);
                                 }
                             }
                         }
                     };
 
                 inferenceSession.generateResponseAsync(resultListener);
-            } catch (Exception e) {
-                callback.onError(e.getMessage());
+            } catch (Exception exception) {
+                callback.onError(exception.getMessage());
             }
         });
     }
 
     public String getReadiness() {
         return isReady ? "ready" : "not_ready";
+    }
+
+    private void resetModelState() {
+        clearChatSessions();
+
+        if (engine != null) {
+            try {
+                engine.close();
+            } catch (Exception exception) {
+                android.util.Log.w("LLM", "Failed to close LiteRT-LM engine", exception);
+            }
+            engine = null;
+        }
+
+        llmInference = null;
+        isReady = false;
+    }
+
+    private void clearChatSessions() {
+        for (ChatSession session : chatSessions.values()) {
+            if (session.conversation != null) {
+                try {
+                    session.conversation.close();
+                } catch (Exception exception) {
+                    android.util.Log.w("LLM", "Failed to close LiteRT-LM conversation", exception);
+                }
+            }
+        }
+
+        chatSessions.clear();
     }
 
     public interface MessageCallback {
@@ -288,17 +447,27 @@ public class LLM {
         void onError(String error);
     }
 
-    // Inner class to manage chat sessions
     private static class ChatSession {
 
-        private StringBuilder history;
+        private final BackendType backendType;
+        private final Conversation conversation;
+        private final StringBuilder history;
 
-        ChatSession() {
+        private ChatSession(BackendType backendType, Conversation conversation) {
+            this.backendType = backendType;
+            this.conversation = conversation;
             this.history = new StringBuilder();
         }
 
+        static ChatSession forLiteRt(Conversation conversation) {
+            return new ChatSession(BackendType.LITERT, conversation);
+        }
+
+        static ChatSession forMediaPipe() {
+            return new ChatSession(BackendType.MEDIAPIPE, null);
+        }
+
         void addMessage(String role, String content) {
-            // Store messages in a cleaner format for history
             if (history.length() > 0) {
                 history.append("\n");
             }
@@ -310,7 +479,6 @@ public class LLM {
         }
 
         String buildPrompt(String newMessage) {
-            // For Gemma with MediaPipe, just return the message as-is
             return newMessage;
         }
     }

--- a/android/src/main/java/ee/forgr/capgo_llm/LLM.java
+++ b/android/src/main/java/ee/forgr/capgo_llm/LLM.java
@@ -41,6 +41,7 @@ public class LLM {
     private String modelPath = null;
     private String modelType = null;
     private BackendType activeBackend = BackendType.LITERT;
+    private long currentLoadId = 0L;
 
     private Integer maxTokens = 2048;
     private Integer topk = 40;
@@ -69,33 +70,43 @@ public class LLM {
         Integer randomSeed,
         ModelLoadCallback callback
     ) {
-        this.modelPath = path;
-        this.modelType = modelType;
-        this.maxTokens = maxTokens;
-        this.topk = topk;
-        this.temperature = temperature;
-        this.randomSeed = randomSeed;
-
+        ModelLoadRequest request = nextLoadRequest(path, modelType, maxTokens, topk, temperature, randomSeed);
         resetModelState();
 
         android.util.Log.d(
             "LLM",
             "setModel called with path: " +
-                path +
+                request.modelPath +
                 ", modelType: " +
-                modelType +
+                request.modelType +
                 ", maxTokens: " +
-                maxTokens +
+                request.maxTokens +
                 ", topk: " +
-                topk +
+                request.topk +
                 ", temperature: " +
-                temperature
+                request.temperature
         );
-        initializeModel(callback);
+        initializeModel(request, callback);
     }
 
-    private void initializeModel(ModelLoadCallback callback) {
-        if (modelPath == null) {
+    private synchronized ModelLoadRequest nextLoadRequest(
+        String path,
+        String modelType,
+        Integer maxTokens,
+        Integer topk,
+        Float temperature,
+        Integer randomSeed
+    ) {
+        currentLoadId += 1;
+        return new ModelLoadRequest(path, modelType, maxTokens, topk, temperature, randomSeed, currentLoadId);
+    }
+
+    private synchronized boolean isCurrentLoad(long loadId) {
+        return loadId == currentLoadId;
+    }
+
+    private void initializeModel(ModelLoadRequest request, ModelLoadCallback callback) {
+        if (request.modelPath == null) {
             if (callback != null) {
                 callback.onError("Model path not set");
             }
@@ -104,23 +115,42 @@ public class LLM {
 
         executor.execute(() -> {
             try {
-                activeBackend = resolveBackend(modelPath, modelType);
-                String actualPath = resolveModelPath(modelPath, activeBackend);
-
-                android.util.Log.d("LLM", "Resolved model path: " + actualPath + " using backend: " + activeBackend);
-
-                if (activeBackend == BackendType.LITERT) {
-                    initializeLiteRtModel(actualPath);
-                } else {
-                    initializeMediaPipeModel(actualPath);
+                if (!isCurrentLoad(request.loadId)) {
+                    notifySupersededLoad(callback);
+                    return;
                 }
 
-                isReady = true;
+                BackendType backend = resolveBackend(request.modelPath, request.modelType);
+                String actualPath = resolveModelPath(request.modelPath, backend);
+
+                android.util.Log.d("LLM", "Resolved model path: " + actualPath + " using backend: " + backend);
+
+                if (backend == BackendType.LITERT) {
+                    Engine loadedEngine = initializeLiteRtModel(actualPath, request);
+                    if (!isCurrentLoad(request.loadId)) {
+                        closeEngine(loadedEngine);
+                        notifySupersededLoad(callback);
+                        return;
+                    }
+                    applyLoadedModel(request, backend, loadedEngine, null);
+                } else {
+                    LlmInference loadedInference = initializeMediaPipeModel(actualPath, request);
+                    if (!isCurrentLoad(request.loadId)) {
+                        notifySupersededLoad(callback);
+                        return;
+                    }
+                    applyLoadedModel(request, backend, null, loadedInference);
+                }
 
                 if (callback != null) {
                     callback.onSuccess();
                 }
             } catch (Exception exception) {
+                if (!isCurrentLoad(request.loadId)) {
+                    notifySupersededLoad(callback);
+                    return;
+                }
+
                 android.util.Log.e("LLM", "Failed to initialize model", exception);
                 resetModelState();
 
@@ -131,26 +161,51 @@ public class LLM {
         });
     }
 
-    private void initializeLiteRtModel(String actualPath) {
+    private void notifySupersededLoad(ModelLoadCallback callback) {
+        if (callback != null) {
+            callback.onError("Model load was superseded by a newer request");
+        }
+    }
+
+    private synchronized void applyLoadedModel(
+        ModelLoadRequest request,
+        BackendType backend,
+        Engine loadedEngine,
+        LlmInference loadedInference
+    ) {
+        modelPath = request.modelPath;
+        modelType = request.modelType;
+        maxTokens = request.maxTokens;
+        topk = request.topk;
+        temperature = request.temperature;
+        randomSeed = request.randomSeed;
+        activeBackend = backend;
+        engine = loadedEngine;
+        llmInference = loadedInference;
+        isReady = true;
+    }
+
+    private Engine initializeLiteRtModel(String actualPath, ModelLoadRequest request) {
         EngineConfig config = new EngineConfig(
             actualPath,
             new Backend.CPU(),
             new Backend.CPU(),
             new Backend.CPU(),
-            maxTokens,
+            request.maxTokens,
             context.getCacheDir().getAbsolutePath()
         );
-        engine = new Engine(config);
-        engine.initialize();
+        Engine loadedEngine = new Engine(config);
+        loadedEngine.initialize();
+        return loadedEngine;
     }
 
-    private void initializeMediaPipeModel(String actualPath) {
+    private LlmInference initializeMediaPipeModel(String actualPath, ModelLoadRequest request) {
         LlmInferenceOptions options = LlmInferenceOptions.builder()
             .setModelPath(actualPath)
-            .setMaxTokens(maxTokens)
-            .setMaxTopK(topk)
+            .setMaxTokens(request.maxTokens)
+            .setMaxTopK(request.topk)
             .build();
-        llmInference = LlmInference.createFromOptions(context, options);
+        return LlmInference.createFromOptions(context, options);
     }
 
     private BackendType resolveBackend(String path, String modelType) {
@@ -318,7 +373,7 @@ public class LLM {
             try {
                 session.addMessage("user", message);
 
-                String fullPrompt = session.buildPrompt(message);
+                String fullPrompt = session.buildPrompt();
                 android.util.Log.d("LLM", "Full prompt: " + fullPrompt);
 
                 com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession.LlmInferenceSessionOptions sessionOptions =
@@ -409,17 +464,22 @@ public class LLM {
     private void resetModelState() {
         clearChatSessions();
 
-        if (engine != null) {
+        closeEngine(engine);
+        engine = null;
+        llmInference = null;
+        modelPath = null;
+        modelType = null;
+        isReady = false;
+    }
+
+    private void closeEngine(Engine loadedEngine) {
+        if (loadedEngine != null) {
             try {
-                engine.close();
+                loadedEngine.close();
             } catch (Exception exception) {
                 android.util.Log.w("LLM", "Failed to close LiteRT-LM engine", exception);
             }
-            engine = null;
         }
-
-        llmInference = null;
-        isReady = false;
     }
 
     private void clearChatSessions() {
@@ -478,8 +538,37 @@ public class LLM {
             }
         }
 
-        String buildPrompt(String newMessage) {
-            return newMessage;
+        String buildPrompt() {
+            return history.toString();
+        }
+    }
+
+    private static class ModelLoadRequest {
+
+        private final String modelPath;
+        private final String modelType;
+        private final Integer maxTokens;
+        private final Integer topk;
+        private final Float temperature;
+        private final Integer randomSeed;
+        private final long loadId;
+
+        private ModelLoadRequest(
+            String modelPath,
+            String modelType,
+            Integer maxTokens,
+            Integer topk,
+            Float temperature,
+            Integer randomSeed,
+            long loadId
+        ) {
+            this.modelPath = modelPath;
+            this.modelType = modelType;
+            this.maxTokens = maxTokens;
+            this.topk = topk;
+            this.temperature = temperature;
+            this.randomSeed = randomSeed;
+            this.loadId = loadId;
         }
     }
 }

--- a/android/src/main/java/ee/forgr/capgo_llm/LLM.java
+++ b/android/src/main/java/ee/forgr/capgo_llm/LLM.java
@@ -11,6 +11,7 @@ import com.google.ai.edge.litertlm.Message;
 import com.google.ai.edge.litertlm.SamplerConfig;
 import com.google.mediapipe.tasks.genai.llminference.LlmInference;
 import com.google.mediapipe.tasks.genai.llminference.LlmInference.LlmInferenceOptions;
+import com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
@@ -370,20 +371,20 @@ public class LLM {
 
     private void sendMessageWithMediaPipe(String chatId, String message, ChatSession session, MessageCallback callback) {
         executor.execute(() -> {
+            LlmInferenceSession inferenceSession = null;
             try {
                 session.addMessage("user", message);
 
                 String fullPrompt = session.buildPrompt();
                 android.util.Log.d("LLM", "Full prompt: " + fullPrompt);
 
-                com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession.LlmInferenceSessionOptions sessionOptions =
-                    com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession.LlmInferenceSessionOptions.builder()
-                        .setTopK(topk)
-                        .setTemperature(temperature)
-                        .build();
+                LlmInferenceSession.LlmInferenceSessionOptions sessionOptions = LlmInferenceSession.LlmInferenceSessionOptions.builder()
+                    .setTopK(topk)
+                    .setTemperature(temperature)
+                    .build();
 
-                com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession inferenceSession =
-                    com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession.createFromOptions(llmInference, sessionOptions);
+                inferenceSession = LlmInferenceSession.createFromOptions(llmInference, sessionOptions);
+                LlmInferenceSession activeSession = inferenceSession;
 
                 inferenceSession.addQueryChunk(fullPrompt);
 
@@ -440,18 +441,14 @@ public class LLM {
                             if (done) {
                                 session.addMessage("assistant", fullResponse.toString());
                                 callback.onComplete(chatId);
-
-                                try {
-                                    inferenceSession.close();
-                                } catch (Exception exception) {
-                                    android.util.Log.e("LLM", "Failed to close MediaPipe session", exception);
-                                }
+                                closeMediaPipeSession(activeSession);
                             }
                         }
                     };
 
                 inferenceSession.generateResponseAsync(resultListener);
             } catch (Exception exception) {
+                closeMediaPipeSession(inferenceSession);
                 callback.onError(exception.getMessage());
             }
         });
@@ -478,6 +475,16 @@ public class LLM {
                 loadedEngine.close();
             } catch (Exception exception) {
                 android.util.Log.w("LLM", "Failed to close LiteRT-LM engine", exception);
+            }
+        }
+    }
+
+    private void closeMediaPipeSession(LlmInferenceSession inferenceSession) {
+        if (inferenceSession != null) {
+            try {
+                inferenceSession.close();
+            } catch (Exception exception) {
+                android.util.Log.e("LLM", "Failed to close MediaPipe session", exception);
             }
         }
     }

--- a/android/src/main/java/ee/forgr/capgo_llm/LLM.java
+++ b/android/src/main/java/ee/forgr/capgo_llm/LLM.java
@@ -216,15 +216,31 @@ public class LLM {
 
     private String normalizeModelType(String path, String modelType) {
         if (modelType != null && !modelType.isBlank()) {
-            return modelType.toLowerCase();
+            return stripUrlSuffix(modelType).toLowerCase();
         }
 
-        int extensionIndex = path.lastIndexOf('.');
-        if (extensionIndex == -1 || extensionIndex == path.length() - 1) {
+        String normalizedPath = stripUrlSuffix(path);
+        int extensionIndex = normalizedPath.lastIndexOf('.');
+        if (extensionIndex == -1 || extensionIndex == normalizedPath.length() - 1) {
             return "";
         }
 
-        return path.substring(extensionIndex + 1).toLowerCase();
+        return normalizedPath.substring(extensionIndex + 1).toLowerCase();
+    }
+
+    private String stripUrlSuffix(String value) {
+        int cutoff = value.length();
+        int queryIndex = value.indexOf('?');
+        int fragmentIndex = value.indexOf('#');
+
+        if (queryIndex >= 0 && queryIndex < cutoff) {
+            cutoff = queryIndex;
+        }
+        if (fragmentIndex >= 0 && fragmentIndex < cutoff) {
+            cutoff = fragmentIndex;
+        }
+
+        return value.substring(0, cutoff);
     }
 
     private String resolveModelPath(String path, BackendType backendType) throws Exception {

--- a/android/src/main/java/ee/forgr/capgo_llm/LLM.java
+++ b/android/src/main/java/ee/forgr/capgo_llm/LLM.java
@@ -16,9 +16,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -51,7 +51,7 @@ public class LLM {
 
     private LLM(Context context) {
         this.context = context;
-        this.chatSessions = new HashMap<>();
+        this.chatSessions = new ConcurrentHashMap<>();
         this.executor = Executors.newSingleThreadExecutor();
     }
 
@@ -137,6 +137,7 @@ public class LLM {
                 } else {
                     LlmInference loadedInference = initializeMediaPipeModel(actualPath, request);
                     if (!isCurrentLoad(request.loadId)) {
+                        closeLlmInference(loadedInference);
                         notifySupersededLoad(callback);
                         return;
                     }
@@ -267,7 +268,7 @@ public class LLM {
         }
     }
 
-    public String createChat() {
+    public synchronized String createChat() {
         if (!isReady) {
             throw new IllegalStateException("Model not ready");
         }
@@ -306,13 +307,24 @@ public class LLM {
     }
 
     public void sendMessage(String chatId, String message, MessageCallback callback) {
-        ChatSession session = chatSessions.get(chatId);
-        if (session == null) {
-            throw new IllegalStateException("Chat session not found");
-        }
+        ChatSession session;
+        LlmInference inference;
+        Integer sessionTopk;
+        Float sessionTemperature;
 
-        if (!isReady) {
-            throw new IllegalStateException("Model not ready");
+        synchronized (this) {
+            session = chatSessions.get(chatId);
+            if (session == null) {
+                throw new IllegalStateException("Chat session not found");
+            }
+
+            if (!isReady) {
+                throw new IllegalStateException("Model not ready");
+            }
+
+            inference = llmInference;
+            sessionTopk = topk;
+            sessionTemperature = temperature;
         }
 
         if (session.backendType == BackendType.LITERT) {
@@ -320,11 +332,11 @@ public class LLM {
             return;
         }
 
-        if (llmInference == null) {
+        if (inference == null) {
             throw new IllegalStateException("MediaPipe model not ready");
         }
 
-        sendMessageWithMediaPipe(chatId, message, session, callback);
+        sendMessageWithMediaPipe(chatId, message, session, inference, sessionTopk, sessionTemperature, callback);
     }
 
     private void sendMessageWithLiteRt(String chatId, String message, ChatSession session, MessageCallback callback) {
@@ -369,7 +381,15 @@ public class LLM {
         return builder.toString();
     }
 
-    private void sendMessageWithMediaPipe(String chatId, String message, ChatSession session, MessageCallback callback) {
+    private void sendMessageWithMediaPipe(
+        String chatId,
+        String message,
+        ChatSession session,
+        LlmInference inference,
+        Integer sessionTopk,
+        Float sessionTemperature,
+        MessageCallback callback
+    ) {
         executor.execute(() -> {
             LlmInferenceSession inferenceSession = null;
             try {
@@ -379,11 +399,11 @@ public class LLM {
                 android.util.Log.d("LLM", "Full prompt: " + fullPrompt);
 
                 LlmInferenceSession.LlmInferenceSessionOptions sessionOptions = LlmInferenceSession.LlmInferenceSessionOptions.builder()
-                    .setTopK(topk)
-                    .setTemperature(temperature)
+                    .setTopK(sessionTopk)
+                    .setTemperature(sessionTemperature)
                     .build();
 
-                inferenceSession = LlmInferenceSession.createFromOptions(llmInference, sessionOptions);
+                inferenceSession = LlmInferenceSession.createFromOptions(inference, sessionOptions);
                 LlmInferenceSession activeSession = inferenceSession;
 
                 inferenceSession.addQueryChunk(fullPrompt);
@@ -454,14 +474,15 @@ public class LLM {
         });
     }
 
-    public String getReadiness() {
+    public synchronized String getReadiness() {
         return isReady ? "ready" : "not_ready";
     }
 
-    private void resetModelState() {
+    private synchronized void resetModelState() {
         clearChatSessions();
 
         closeEngine(engine);
+        closeLlmInference(llmInference);
         engine = null;
         llmInference = null;
         modelPath = null;
@@ -485,6 +506,16 @@ public class LLM {
                 inferenceSession.close();
             } catch (Exception exception) {
                 android.util.Log.e("LLM", "Failed to close MediaPipe session", exception);
+            }
+        }
+    }
+
+    private void closeLlmInference(LlmInference inference) {
+        if (inference != null) {
+            try {
+                inference.close();
+            } catch (Exception exception) {
+                android.util.Log.w("LLM", "Failed to close MediaPipe model", exception);
             }
         }
     }

--- a/android/src/main/java/ee/forgr/capgo_llm/LLMPlugin.java
+++ b/android/src/main/java/ee/forgr/capgo_llm/LLMPlugin.java
@@ -104,7 +104,7 @@ public class LLMPlugin extends Plugin {
         Integer maxTokens = call.getInt("maxTokens", 2048);
         Integer topk = call.getInt("topk", 40);
         Float temperature = call.getFloat("temperature", 0.8f);
-        Integer randomSeed = call.getInt("randomSeed", 101);
+        Integer randomSeed = call.getInt("randomSeed", 0);
         String modelType = call.getString("modelType");
 
         llm.setModel(

--- a/android/src/main/java/ee/forgr/capgo_llm/LLMPlugin.java
+++ b/android/src/main/java/ee/forgr/capgo_llm/LLMPlugin.java
@@ -41,34 +41,40 @@ public class LLMPlugin extends Plugin {
             return;
         }
 
-        llm.sendMessage(
-            chatId,
-            message,
-            new LLM.MessageCallback() {
-                @Override
-                public void onTextReceived(String chatId, String text, boolean isChunk) {
-                    JSObject event = new JSObject();
-                    event.put("text", text);
-                    event.put("chatId", chatId);
-                    event.put("isChunk", isChunk);
-                    notifyListeners("textFromAi", event);
-                }
+        try {
+            llm.sendMessage(
+                chatId,
+                message,
+                new LLM.MessageCallback() {
+                    @Override
+                    public void onTextReceived(String chatId, String text, boolean isChunk) {
+                        JSObject event = new JSObject();
+                        event.put("text", text);
+                        event.put("chatId", chatId);
+                        event.put("isChunk", isChunk);
+                        notifyListeners("textFromAi", event);
+                    }
 
-                @Override
-                public void onComplete(String chatId) {
-                    JSObject event = new JSObject();
-                    event.put("chatId", chatId);
-                    notifyListeners("aiFinished", event);
-                }
+                    @Override
+                    public void onComplete(String chatId) {
+                        JSObject event = new JSObject();
+                        event.put("chatId", chatId);
+                        notifyListeners("aiFinished", event);
+                    }
 
-                @Override
-                public void onError(String error) {
-                    call.reject("Failed to send message", error);
+                    @Override
+                    public void onError(String error) {
+                        JSObject event = new JSObject();
+                        event.put("readiness", "Failed to generate response: " + error);
+                        notifyListeners("readinessChange", event);
+                    }
                 }
-            }
-        );
+            );
 
-        call.resolve();
+            call.resolve();
+        } catch (IllegalStateException exception) {
+            call.reject(exception.getMessage());
+        }
     }
 
     @PluginMethod
@@ -98,12 +104,15 @@ public class LLMPlugin extends Plugin {
         Integer topk = call.getInt("topk", 40);
         Float temperature = call.getFloat("temperature", 0.8f);
         Integer randomSeed = call.getInt("randomSeed", 101);
+        String modelType = call.getString("modelType");
 
         llm.setModel(
             path,
+            modelType,
             maxTokens,
             topk,
             temperature,
+            randomSeed,
             new LLM.ModelLoadCallback() {
                 @Override
                 public void onSuccess() {

--- a/android/src/main/java/ee/forgr/capgo_llm/LLMPlugin.java
+++ b/android/src/main/java/ee/forgr/capgo_llm/LLMPlugin.java
@@ -65,8 +65,9 @@ public class LLMPlugin extends Plugin {
                     @Override
                     public void onError(String error) {
                         JSObject event = new JSObject();
-                        event.put("readiness", "Failed to generate response: " + error);
-                        notifyListeners("readinessChange", event);
+                        event.put("chatId", chatId);
+                        event.put("error", error);
+                        notifyListeners("generationError", event);
                     }
                 }
             );

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -1,288 +1,72 @@
 # Capacitor LLM Example App
 
-This example app demonstrates how to use the @capgo/capacitor-llm plugin in a real application.
+This example app shows the current recommended plugin flows:
 
-## Prerequisites
-
-- Node.js and npm/bun installed
-- Xcode (for iOS development)
-- Android Studio (for Android development)
-- Capacitor CLI
+- iOS: Apple Intelligence by default
+- Android: LiteRT-LM with Gemma 4 downloads
 
 ## Setup
 
-1. Install dependencies:
 ```bash
 bun install
+bunx cap sync
 ```
 
-2. Sync Capacitor:
-```bash
-npx cap sync
-```
+## iOS
 
-## Getting and Adding Models for Testing
+The example defaults to Apple Intelligence.
 
-### iOS Setup
+Requirements:
 
-#### Option 1: Use Apple Intelligence (Recommended - iOS 18.2+)
+- iOS 26.0+
+- Apple Intelligence enabled on the device
 
-The easiest way to test on iOS is to use Apple Intelligence, which requires no model downloads:
+Optional legacy custom-model path:
 
-1. Ensure your device runs iOS 18.2 or later
-2. Enable Apple Intelligence in Settings > Apple Intelligence & Siri
-3. In your app code, use:
-```typescript
-await CapgoLLM.setModel({ path: 'Apple Intelligence' });
-```
+- The plugin still supports bundled MediaPipe `.task` models on iOS.
+- Add the file to the Xcode target's "Copy Bundle Resources".
+- Select `Gemma 2 2B (Legacy MediaPipe)` from the in-app model picker.
 
-No additional setup required!
+## Android
 
-#### Option 2: Use Custom MediaPipe Models (Experimental)
+The example is now centered on Gemma 4 with LiteRT-LM.
 
-**⚠️ Warning**: Custom models on iOS have compatibility issues and may not work reliably. Use Apple Intelligence instead when possible.
+Available in the model picker:
 
-If you want to try custom models anyway:
+- `Gemma 4 E2B (LiteRT-LM)`
+- `Gemma 4 E4B (LiteRT-LM)`
 
-1. **Download a Gemma-2 2B model**:
-   - Visit [Hugging Face MediaPipe Models](https://huggingface.co/collections/google/mediapipe-668392ead2d6768e82fb3b87)
-   - Look for models named `Gemma2-2B-IT_*_ekv*.task`
-   - Example: Download `Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280.task`
-   - Note: These files are typically 1-2GB in size
+The app downloads the models directly from the public `litert-community` Hugging Face repositories:
 
-2. **Add the model to Xcode**:
-   - Open the iOS project in Xcode:
-     ```bash
-     npx cap open ios
-     ```
-   - Right-click on the `App` folder in the project navigator
-   - Select "Add Files to 'App'..."
-   - Select your downloaded `.task` file
-   - **Important**: Check "Copy items if needed"
-   - **Important**: In "Add to targets", make sure "App" is checked
+- [Gemma 4 E2B LiteRT-LM](https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm)
+- [Gemma 4 E4B LiteRT-LM](https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm)
 
-3. **Verify the model is in the bundle**:
-   - Select your app target
-   - Go to "Build Phases" tab
-   - Expand "Copy Bundle Resources"
-   - Make sure your `.task` file is listed there
+If you prefer to bundle a model manually, place a `.litertlm` file in your Android app assets and call:
 
-4. **Use the model in your code**:
-```typescript
-import { CapgoLLM } from '@capgo/capacitor-llm';
-
+```ts
 await CapgoLLM.setModel({
-  path: 'Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280',  // Without .task extension
-  modelType: 'task',
-  maxTokens: 1280
+  path: '/android_asset/gemma-4-E2B-it.litertlm',
+  modelType: 'litertlm',
+  maxTokens: 4096,
 });
 ```
 
-### Android Setup
-
-Android requires you to bundle or download models, as there's no built-in equivalent to Apple Intelligence yet.
-
-#### Step 1: Download the Model
-
-**Recommended: Gemma-3 270M** (Smallest and fastest)
-
-1. Go to [Kaggle Gemma Models](https://www.kaggle.com/models/google/gemma)
-2. Select the model you want (recommended: Gemma 3 270M)
-3. Click on the **"LiteRT (formerly TFLite)"** tab
-4. Download BOTH files:
-   - `gemma-3-270m-it-int8.task` (~240MB)
-   - `gemma-3-270m-it-int8.litertlm` (~4MB)
-
-**Note**: You'll need a Kaggle account to download models. Sign up at [kaggle.com](https://www.kaggle.com) if you don't have one.
-
-Alternative models (larger, more capable):
-- Gemma-3 1B (~892MB-1.5GB)
-- Gemma-2 2B (~1-2GB)
-
-#### Step 2: Add Models to Your Android App
-
-**Option A: Bundle in the APK** (for testing)
-
-1. Create the assets directory if it doesn't exist:
-```bash
-mkdir -p android/app/src/main/assets
-```
-
-2. Copy BOTH model files to the assets directory:
-```bash
-cp gemma-3-270m-it-int8.task android/app/src/main/assets/
-cp gemma-3-270m-it-int8.litertlm android/app/src/main/assets/
-```
-
-3. Verify the files are in place:
-```bash
-ls -lh android/app/src/main/assets/
-```
-
-4. Use the model in your code:
-```typescript
-import { CapgoLLM } from '@capgo/capacitor-llm';
-
-// The /android_asset/ prefix references the assets folder
-await CapgoLLM.setModel({
-  path: '/android_asset/gemma-3-270m-it-int8.task',
-  maxTokens: 2048
-});
-```
-
-**Option B: Download at Runtime** (for production apps)
-
-For production, you'll want to download models at runtime to keep your APK size small:
-
-```typescript
-import { CapgoLLM, Filesystem, Directory } from '@capgo/capacitor-llm';
-
-async function downloadAndSetModel() {
-  // Download the model files
-  const modelUrl = 'https://your-server.com/models/gemma-3-270m-it-int8.task';
-  const companionUrl = 'https://your-server.com/models/gemma-3-270m-it-int8.litertlm';
-
-  // Use the plugin's download function with progress tracking
-  const result = await CapgoLLM.downloadModel({
-    url: modelUrl,
-    filename: 'gemma-3-270m-it-int8.task',
-    companionUrl: companionUrl
-  });
-
-  // The plugin returns the path where files were saved
-  await CapgoLLM.setModel({
-    path: result.path,
-    maxTokens: 2048
-  });
-}
-```
-
-#### Step 3: Update minSdkVersion
-
-Ensure your `android/variables.gradle` has the correct minimum SDK version:
-
-```gradle
-ext {
-    minSdkVersion = 24
-    compileSdkVersion = 34
-    targetSdkVersion = 34
-    // ... other settings
-}
-```
-
-## Running the Example App
-
-### iOS
+## Run
 
 ```bash
-npx cap run ios
+bunx cap run ios
+bunx cap run android
 ```
 
-Or open in Xcode:
-```bash
-npx cap open ios
-```
-
-### Android
+Or open the native projects:
 
 ```bash
-npx cap run android
+bunx cap open ios
+bunx cap open android
 ```
 
-Or open in Android Studio:
-```bash
-npx cap open android
-```
+## Notes
 
-## Testing the Plugin
-
-Once you have the models set up, you can test the plugin:
-
-```typescript
-import { CapgoLLM } from '@capgo/capacitor-llm';
-
-// 1. Set up the model (choose one based on your platform)
-// For iOS with Apple Intelligence:
-await CapgoLLM.setModel({ path: 'Apple Intelligence' });
-
-// For Android with bundled model:
-await CapgoLLM.setModel({ path: '/android_asset/gemma-3-270m-it-int8.task' });
-
-// 2. Check if the model is ready
-const { readiness } = await CapgoLLM.getReadiness();
-console.log('Model readiness:', readiness);
-
-// 3. Create a chat session
-const { id } = await CapgoLLM.createChat({
-  instructions: 'You are a helpful assistant.'
-});
-
-// 4. Listen for responses
-CapgoLLM.addListener('textFromAi', (data) => {
-  console.log('Received chunk:', data.text);
-});
-
-CapgoLLM.addListener('aiFinished', () => {
-  console.log('AI finished responding');
-});
-
-// 5. Send a message
-await CapgoLLM.sendMessage({
-  chatId: id,
-  message: 'Hello! Tell me a short joke.'
-});
-```
-
-## Troubleshooting
-
-### iOS Issues
-
-1. **"Model file not found in bundle"**:
-   - Verify the model is added to "Copy Bundle Resources" in Build Phases
-   - Check that you're using the filename without the extension in `setModel()`
-   - Clean build folder (Cmd+Shift+K) and rebuild
-
-2. **"prefill_input_names.size() % 2)==(0)" error**:
-   - This is a known compatibility issue with `.task` format models on iOS
-   - Switch to Apple Intelligence instead: `setModel({ path: 'Apple Intelligence' })`
-
-3. **Apple Intelligence not available**:
-   - Ensure your device runs iOS 18.2 or later
-   - Enable Apple Intelligence in Settings
-   - Some devices may not support Apple Intelligence
-
-### Android Issues
-
-1. **"Model file not found"**:
-   - Verify both `.task` and `.litertlm` files are in `android/app/src/main/assets/`
-   - Rebuild the app to include new assets
-   - Check file names match exactly (case-sensitive)
-
-2. **App crashes on model load**:
-   - Check that `minSdkVersion` is set to 24 or higher
-   - Ensure you have enough device memory (models can be large)
-   - Try a smaller model like Gemma-3 270M
-
-3. **"Insufficient memory"**:
-   - Use a smaller model (Gemma-3 270M instead of 1B or 2B)
-   - Reduce `maxTokens` parameter
-   - Close other apps to free up memory
-
-## Model Size Reference
-
-When choosing a model, consider these approximate sizes:
-
-| Model | Size | RAM Usage | Speed | Best For |
-|-------|------|-----------|-------|----------|
-| Gemma-3 270M | ~240-400MB | Low | Fast | Testing, simple tasks |
-| Gemma-3 1B | ~892MB-1.5GB | Medium | Medium | Balanced performance |
-| Gemma-2 2B | ~1-2GB | High | Slower | Best quality responses |
-
-For testing purposes, start with Gemma-3 270M on Android or Apple Intelligence on iOS.
-
-## Additional Resources
-
-- [Plugin Documentation](https://capgo.app/docs/plugins/llm/)
-- [Kaggle Gemma Models](https://www.kaggle.com/models/google/gemma)
-- [Hugging Face MediaPipe Models](https://huggingface.co/collections/google/mediapipe-668392ead2d6768e82fb3b87)
-- [MediaPipe GenAI Documentation](https://developers.google.com/mediapipe/solutions/genai/llm_inference)
+- Android now prefers `.litertlm` bundles through LiteRT-LM.
+- Legacy Android `.task` models still work through the compatibility fallback in the plugin.
+- Web still uses MediaPipe `.task` models and is not demonstrated by this example app.

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -2,8 +2,9 @@
 
 This example app shows the current recommended plugin flows:
 
-- iOS: Apple Intelligence by default
+- iOS: Apple Intelligence by default, plus downloadable Gemma 4 LiteRT-LM models
 - Android: LiteRT-LM with Gemma 4 downloads
+- Web: Gemma 4 web models through `@mediapipe/tasks-genai`
 
 ## Setup
 
@@ -20,6 +21,12 @@ Requirements:
 
 - iOS 26.0+
 - Apple Intelligence enabled on the device
+
+Optional Gemma 4 custom-model path:
+
+- `Gemma 4 E2B (LiteRT-LM)`
+- `Gemma 4 E4B (LiteRT-LM)`
+- The app downloads the `.litertlm` bundles directly from `litert-community`.
 
 Optional legacy custom-model path:
 
@@ -51,6 +58,15 @@ await CapgoLLM.setModel({
 });
 ```
 
+## Web
+
+Available in the model picker:
+
+- `Gemma 4 E2B (Web)`
+- `Gemma 4 E4B (Web)`
+
+These load the web-specific `*-web.task` artifacts from the same `litert-community` Hugging Face repos and require a WebGPU-capable browser.
+
 ## Run
 
 ```bash
@@ -68,5 +84,6 @@ bunx cap open android
 ## Notes
 
 - Android now prefers `.litertlm` bundles through LiteRT-LM.
+- iOS custom-model sessions can also load downloaded `.litertlm` bundles.
 - Legacy Android `.task` models still work through the compatibility fallback in the plugin.
-- Web still uses MediaPipe `.task` models and is not demonstrated by this example app.
+- Web uses Gemma 4 `*-web.task` artifacts through `@mediapipe/tasks-genai`.

--- a/example-app/src/views/HomePage.vue
+++ b/example-app/src/views/HomePage.vue
@@ -78,18 +78,18 @@
     <ion-footer>
       <ion-toolbar>
         <ion-item class="message-input-item">
-          <ion-input 
+          <ion-input
             v-model="newMessage"
-            placeholder="Type a message..." 
+            :placeholder="inputPlaceholder"
             class="message-input"
             @keyup.enter="sendMessage"
           ></ion-input>
-          <ion-button 
-            slot="end" 
-            fill="solid" 
-            shape="round" 
+          <ion-button
+            slot="end"
+            fill="solid"
+            shape="round"
             @click="sendMessage"
-            :disabled="!newMessage.trim()"
+            :disabled="!canSendMessage"
             class="send-button"
           >
             <ion-icon :icon="sendIcon" />
@@ -174,7 +174,6 @@ import {
   IonIcon,
   IonFooter,
   IonChip,
-  IonToggle,
   IonModal,
   IonButtons,
   IonProgressBar,
@@ -206,31 +205,27 @@ const isDownloading = ref(false);
 const selectedModel = ref('apple-intelligence');
 const showModelSelector = ref(false);
 let listenerRemove: (() => Promise<void>) | null = null;
-let readinessInterval: NodeJS.Timeout | null = null;
 
-const messages = ref<Message[]>([
-  {
-    id: 1,
-    text: "What is life?",
-    isUser: true,
-    timestamp: new Date(),
-    isComplete: true
-  },
-  {
-    id: 2,
-    text: "life is fun!",
-    isUser: false,
-    timestamp: new Date(),
-    isComplete: true
-  }
-]);
-
-let messageIdCounter = 3;
-
-// Model selection state
-const useMediaPipe = ref(false);
+const messages = ref<Message[]>([]);
+let messageIdCounter = 1;
 const isIOS = computed(() => Capacitor.getPlatform() === 'ios');
 const isAndroid = computed(() => Capacitor.getPlatform() === 'android');
+const canSendMessage = computed(() => Boolean(newMessage.value.trim()) && Boolean(chatId.value) && readinessStatus.value === 'ready');
+const inputPlaceholder = computed(() => {
+  if (chatId.value) {
+    return 'Type a message...';
+  }
+
+  if (isAndroid.value) {
+    return 'Select a Gemma 4 model first...';
+  }
+
+  if (isIOS.value) {
+    return 'Preparing Apple Intelligence...';
+  }
+
+  return 'Load a model first...';
+});
 
 // Model type definition
 interface Model {
@@ -240,7 +235,6 @@ interface Model {
   url?: string;
   companionUrl?: string;
   filename?: string;
-  companionFilename?: string;
   path?: string;
   modelType?: string;
   maxTokens?: number;
@@ -258,55 +252,35 @@ const models: { ios: Model[], android: Model[] } = {
       note: 'System LLM - no download needed'
     },
     {
-      id: 'gemma2-2b-bundled',
-      name: 'Gemma 2 2B (Bundled)',
+      id: 'gemma2-2b-legacy',
+      name: 'Gemma 2 2B (Legacy MediaPipe)',
       needsDownload: false,
       path: 'Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280',
       modelType: 'task',
       maxTokens: 1280,
-      note: 'Pre-installed in app bundle (if added to Xcode)'
-    },
-    { 
-      id: 'gemma2-2b-download', 
-      name: 'Gemma 2 2B (Download)', 
-      needsDownload: true,
-      // Note: This is a placeholder URL - actual MediaPipe models need manual download
-      url: 'https://example.com/gemma2-2b.task',
-      filename: 'Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280.task',
-      path: 'Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280',
-      modelType: 'task',
-      maxTokens: 1280,
-      note: 'Demo - replace URL with actual model URL'
+      note: 'Manual bundle setup only. Android is the Gemma 4 LiteRT showcase.'
     }
   ],
   android: [
-    { 
-      id: 'gemma3-270m', 
-      name: 'Gemma 3 270M (Bundled)', 
-      needsDownload: false,
-      path: '/android_asset/gemma-3-270m-it-int8.task',
-      maxTokens: 2048,
-      note: 'Pre-installed in assets folder'
-    },
     {
-      id: 'gemma3-1b-bundled',
-      name: 'Gemma 3 1B (Bundled)',
-      needsDownload: false,
-      path: '/android_asset/gemma-3-1b-it-int8.task',
-      maxTokens: 2048,
-      note: 'Pre-installed in assets folder (if added)'
-    },
-    {
-      id: 'gemma3-270m-download',
-      name: 'Gemma 3 270M (Download)',
+      id: 'gemma4-e2b-download',
+      name: 'Gemma 4 E2B (LiteRT-LM)',
       needsDownload: true,
-      // This is a demo URL - replace with actual model URL
-      url: 'https://example.com/gemma-3-270m-it-int8.task',
-      companionUrl: 'https://example.com/gemma-3-270m-it-int8.litertlm',
-      filename: 'gemma-3-270m-it-int8.task',
-      companionFilename: 'gemma-3-270m-it-int8.litertlm',
-      maxTokens: 2048,
-      note: 'Demo - replace URLs with actual model URLs'
+      url: 'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm?download=true',
+      filename: 'gemma-4-E2B-it.litertlm',
+      modelType: 'litertlm',
+      maxTokens: 4096,
+      note: 'Recommended Android model. Real LiteRT-LM bundle from litert-community.'
+    },
+    {
+      id: 'gemma4-e4b-download',
+      name: 'Gemma 4 E4B (LiteRT-LM)',
+      needsDownload: true,
+      url: 'https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm/resolve/main/gemma-4-E4B-it.litertlm?download=true',
+      filename: 'gemma-4-E4B-it.litertlm',
+      modelType: 'litertlm',
+      maxTokens: 4096,
+      note: 'Larger Gemma 4 variant for devices with more RAM.'
     }
   ]
 };
@@ -330,6 +304,22 @@ const scrollToBottom = async () => {
   }
 };
 
+const setConversationIntro = (text: string) => {
+  messages.value = [
+    {
+      id: 1,
+      text,
+      isUser: false,
+      timestamp: new Date(),
+      isComplete: true,
+    },
+  ];
+  messageIdCounter = 2;
+  currentAiMessageId.value = null;
+  rawMessages.clear();
+  isThinking.value = false;
+};
+
 const isTypingComplete = (message: Message) => {
   return message.isComplete !== false;
 };
@@ -338,11 +328,15 @@ const getReadinessColor = () => {
   switch (readinessStatus.value) {
     case 'ready':
       return 'success';
-    case 'notReady':
+    case 'loading':
+    case 'not_ready':
       return 'warning';
-    case 'notSupported':
+    case 'error':
       return 'danger';
     default:
+      if (readinessStatus.value.toLowerCase().startsWith('failed')) {
+        return 'danger';
+      }
       return 'medium';
   }
 };
@@ -353,7 +347,7 @@ const checkReadiness = async () => {
     readinessStatus.value = result.readiness;
   } catch (error) {
     console.error('Error checking readiness:', error);
-    readinessStatus.value = 'Error';
+    readinessStatus.value = 'error';
   }
 };
 
@@ -388,7 +382,7 @@ const handleAiResponse = async (event: TextFromAiEvent) => {
 };
 
 const sendMessage = async () => {
-  if (newMessage.value.trim() && chatId.value) {
+  if (canSendMessage.value) {
     // Add user message
     const userMessage: Message = {
       id: messageIdCounter++,
@@ -488,13 +482,10 @@ const downloadModel = async (model: Model) => {
 const selectModel = async (model: Model) => {
   try {
     selectedModel.value = model.id;
-    
-    // Clear existing chat
-    if (chatId.value) {
-      chatId.value = '';
-      messages.value = [];
-    }
-    
+
+    chatId.value = '';
+    setConversationIntro(`Preparing ${model.name}...`);
+
     if (model.id === 'apple-intelligence') {
       await CapgoLLM.setModel({ path: 'Apple Intelligence' });
     } else if (model.downloadedPath || !model.needsDownload) {
@@ -513,6 +504,7 @@ const selectModel = async (model: Model) => {
     
     // Recreate chat
     await initializeChat();
+    setConversationIntro(`${model.name} is ready. Ask anything.`);
     showModelSelector.value = false;
     
   } catch (error) {
@@ -535,6 +527,8 @@ const initializeChat = async () => {
 
 onMounted(async () => {
   try {
+    setConversationIntro('Checking model readiness...');
+
     // Set up readiness listener
     const readinessListener = await CapgoLLM.addListener('readinessChange', (event) => {
       readinessStatus.value = event.readiness;
@@ -545,31 +539,23 @@ onMounted(async () => {
     await checkReadiness();
     
     // Set model path based on platform
-    // This is optional - if not called, iOS will use Apple Intelligence by default
     try {
       const platform = Capacitor.getPlatform();
-      if (platform === 'android') {
-        // Use the downloaded Gemma 3 270M model for Android
-        await CapgoLLM.setModel({ 
-          path: '/android_asset/gemma-3-270m-it-int8.task',
-          maxTokens: 2048,
-          topk: 40,
-          temperature: 0.8
-        });
-        selectedModel.value = 'gemma3-270m';
-        console.log('Android: Using Gemma 3 270M model');
-      } else if (platform === 'ios') {
-        // Default to Apple Intelligence on iOS
+      if (platform === 'ios') {
         selectedModel.value = 'apple-intelligence';
+        await CapgoLLM.setModel({ path: 'Apple Intelligence' });
+        await initializeChat();
+        setConversationIntro('Apple Intelligence is ready. Ask anything.');
         console.log('iOS: Using Apple Intelligence (default)');
+      } else if (platform === 'android') {
+        selectedModel.value = 'gemma4-e2b-download';
+        readinessStatus.value = 'not_ready';
+        setConversationIntro('Select a Gemma 4 LiteRT-LM model from the Model menu to start chatting.');
       }
     } catch (modelError) {
       console.warn('Model setup error (using defaults):', modelError);
     }
-    
-    // Initialize chat
-    await initializeChat();
-    
+
     // Set up listener for AI responses
     const textFromAiListener = await CapgoLLM.addListener('textFromAi', handleAiResponse);
     const aiFinishedListener = await CapgoLLM.addListener('aiFinished', handleAiFinished);
@@ -883,4 +869,3 @@ ion-footer ion-toolbar {
   align-items: center;
 }
 </style>
-

--- a/example-app/src/views/HomePage.vue
+++ b/example-app/src/views/HomePage.vue
@@ -211,6 +211,7 @@ const messages = ref<Message[]>([]);
 let messageIdCounter = 1;
 const isIOS = computed(() => Capacitor.getPlatform() === 'ios');
 const isAndroid = computed(() => Capacitor.getPlatform() === 'android');
+const isWeb = computed(() => Capacitor.getPlatform() === 'web');
 const canSendMessage = computed(() => Boolean(newMessage.value.trim()) && Boolean(chatId.value) && readinessStatus.value === 'ready');
 const inputPlaceholder = computed(() => {
   if (chatId.value) {
@@ -223,6 +224,10 @@ const inputPlaceholder = computed(() => {
 
   if (isIOS.value) {
     return 'Preparing Apple Intelligence...';
+  }
+
+  if (isWeb.value) {
+    return 'Select a Gemma 4 web model first...';
   }
 
   return 'Load a model first...';
@@ -244,7 +249,7 @@ interface Model {
 }
 
 // Available models
-const models: { ios: Model[], android: Model[] } = {
+const models: { ios: Model[], android: Model[], web: Model[] } = {
   ios: [
     { 
       id: 'apple-intelligence', 
@@ -253,13 +258,33 @@ const models: { ios: Model[], android: Model[] } = {
       note: 'System LLM - no download needed'
     },
     {
+      id: 'gemma4-e2b-ios-download',
+      name: 'Gemma 4 E2B (LiteRT-LM)',
+      needsDownload: true,
+      url: 'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it.litertlm?download=true',
+      filename: 'gemma-4-E2B-it.litertlm',
+      modelType: 'litertlm',
+      maxTokens: 4096,
+      note: 'Downloads the iOS/mobile Gemma 4 LiteRT-LM bundle.'
+    },
+    {
+      id: 'gemma4-e4b-ios-download',
+      name: 'Gemma 4 E4B (LiteRT-LM)',
+      needsDownload: true,
+      url: 'https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm/resolve/main/gemma-4-E4B-it.litertlm?download=true',
+      filename: 'gemma-4-E4B-it.litertlm',
+      modelType: 'litertlm',
+      maxTokens: 4096,
+      note: 'Larger iOS/mobile Gemma 4 variant for devices with more RAM.'
+    },
+    {
       id: 'gemma2-2b-legacy',
       name: 'Gemma 2 2B (Legacy MediaPipe)',
       needsDownload: false,
       path: 'Gemma2-2B-IT_multi-prefill-seq_q8_ekv1280',
       modelType: 'task',
       maxTokens: 1280,
-      note: 'Manual bundle setup only. Android is the Gemma 4 LiteRT showcase.'
+      note: 'Manual bundle setup only. Kept as a legacy compatibility path.'
     }
   ],
   android: [
@@ -283,13 +308,34 @@ const models: { ios: Model[], android: Model[] } = {
       maxTokens: 4096,
       note: 'Larger Gemma 4 variant for devices with more RAM.'
     }
+  ],
+  web: [
+    {
+      id: 'gemma4-e2b-web',
+      name: 'Gemma 4 E2B (Web)',
+      needsDownload: false,
+      path: 'https://huggingface.co/litert-community/gemma-4-E2B-it-litert-lm/resolve/main/gemma-4-E2B-it-web.task?download=true',
+      modelType: 'task',
+      maxTokens: 4096,
+      note: 'WebGPU-ready Gemma 4 artifact served directly from Hugging Face.'
+    },
+    {
+      id: 'gemma4-e4b-web',
+      name: 'Gemma 4 E4B (Web)',
+      needsDownload: false,
+      path: 'https://huggingface.co/litert-community/gemma-4-E4B-it-litert-lm/resolve/main/gemma-4-E4B-it-web.task?download=true',
+      modelType: 'task',
+      maxTokens: 4096,
+      note: 'Larger Gemma 4 web model. Chrome/WebGPU and more memory recommended.'
+    }
   ]
 };
 
 const availableModels = computed(() => {
   if (isIOS.value) return models.ios;
   if (isAndroid.value) return models.android;
-  return [];
+  if (isWeb.value) return models.web;
+  return models.web;
 });
 
 const refresh = (ev: CustomEvent) => {
@@ -618,12 +664,16 @@ onMounted(async () => {
         selectedModel.value = 'apple-intelligence';
         await CapgoLLM.setModel({ path: 'Apple Intelligence' });
         await initializeChat();
-        setConversationIntro('Apple Intelligence is ready. Ask anything.');
+        setConversationIntro('Apple Intelligence is ready. Open Model to switch to Gemma 4 LiteRT-LM.');
         console.log('iOS: Using Apple Intelligence (default)');
       } else if (platform === 'android') {
         selectedModel.value = 'gemma4-e2b-download';
         readinessStatus.value = 'not_ready';
         setConversationIntro('Select a Gemma 4 LiteRT-LM model from the Model menu to start chatting.');
+      } else {
+        selectedModel.value = 'gemma4-e2b-web';
+        readinessStatus.value = 'not_ready';
+        setConversationIntro('Select a Gemma 4 web model from the Model menu to start chatting.');
       }
     } catch (modelError) {
       console.warn('Model setup error (using defaults):', modelError);

--- a/example-app/src/views/HomePage.vue
+++ b/example-app/src/views/HomePage.vue
@@ -88,6 +88,7 @@
             slot="end"
             fill="solid"
             shape="round"
+            aria-label="Send message"
             @click="sendMessage"
             :disabled="!canSendMessage"
             class="send-button"
@@ -320,6 +321,26 @@ const setConversationIntro = (text: string) => {
   isThinking.value = false;
 };
 
+const cloneMessages = () => messages.value.map((message) => ({
+  ...message,
+  timestamp: new Date(message.timestamp),
+}));
+
+const restoreConversationState = (
+  snapshotMessages: Message[],
+  snapshotRawMessages: Map<number, string>,
+  snapshotMessageIdCounter: number,
+) => {
+  messages.value = snapshotMessages;
+  rawMessages.clear();
+  snapshotRawMessages.forEach((value, key) => {
+    rawMessages.set(key, value);
+  });
+  messageIdCounter = snapshotMessageIdCounter;
+  currentAiMessageId.value = null;
+  isThinking.value = false;
+};
+
 const isTypingComplete = (message: Message) => {
   return message.isComplete !== false;
 };
@@ -466,6 +487,39 @@ const handleGenerationError = (event: GenerationErrorEvent) => {
   isThinking.value = false;
 };
 
+const applyModel = async (model: Model) => {
+  if (model.id === 'apple-intelligence') {
+    await CapgoLLM.setModel({ path: 'Apple Intelligence' });
+    return;
+  }
+
+  const path = model.downloadedPath || model.path;
+  if (!path) {
+    throw new Error('Model path is not available yet');
+  }
+
+  await CapgoLLM.setModel({
+    path,
+    modelType: model.modelType,
+    maxTokens: model.maxTokens,
+    topk: 40,
+    temperature: 0.8
+  });
+};
+
+const getModelById = (id: string) => availableModels.value.find((model) => model.id === id);
+
+const restorePreviousModel = async (modelId: string) => {
+  const previousModel = getModelById(modelId);
+  if (!previousModel) {
+    chatId.value = '';
+    return;
+  }
+
+  await applyModel(previousModel);
+  await initializeChat();
+};
+
 const downloadModel = async (model: Model) => {
   if (!model.needsDownload || !model.url) return;
   
@@ -497,35 +551,37 @@ const downloadModel = async (model: Model) => {
 };
 
 const selectModel = async (model: Model) => {
+  const previousSelectedModel = selectedModel.value;
+  const snapshotMessages = cloneMessages();
+  const snapshotRawMessages = new Map(rawMessages);
+  const snapshotMessageIdCounter = messageIdCounter;
+
   try {
-    selectedModel.value = model.id;
-
-    chatId.value = '';
-    setConversationIntro(`Preparing ${model.name}...`);
-
-    if (model.id === 'apple-intelligence') {
-      await CapgoLLM.setModel({ path: 'Apple Intelligence' });
-    } else if (model.downloadedPath || !model.needsDownload) {
-      await CapgoLLM.setModel({
-        path: model.downloadedPath || model.path || '',
-        modelType: model.modelType,
-        maxTokens: model.maxTokens,
-        topk: 40,
-        temperature: 0.8
-      });
-    } else {
+    if (model.needsDownload && !model.downloadedPath) {
       // Need to download first
       await downloadModel(model);
       return;
     }
-    
-    // Recreate chat
+
+    await applyModel(model);
     await initializeChat();
+    selectedModel.value = model.id;
     setConversationIntro(`${model.name} is ready. Ask anything.`);
     showModelSelector.value = false;
-    
   } catch (error) {
     console.error('Error selecting model:', error);
+    restoreConversationState(snapshotMessages, snapshotRawMessages, snapshotMessageIdCounter);
+    selectedModel.value = previousSelectedModel;
+
+    if (previousSelectedModel) {
+      try {
+        await restorePreviousModel(previousSelectedModel);
+      } catch (restoreError) {
+        console.error('Error restoring previous model:', restoreError);
+        chatId.value = '';
+      }
+    }
+
     alert(`Failed to load model: ${error}`);
   }
 };

--- a/example-app/src/views/HomePage.vue
+++ b/example-app/src/views/HomePage.vue
@@ -180,7 +180,7 @@ import {
 } from '@ionic/vue';
 import { send, settingsOutline, checkmarkCircle, cloudDownloadOutline, checkmarkDoneOutline, checkmarkOutline } from 'ionicons/icons';
 import { ref, nextTick, onMounted, onUnmounted, computed } from 'vue';
-import type { TextFromAiEvent, AiFinishedEvent } from '@capgo/capacitor-llm';
+import type { TextFromAiEvent, AiFinishedEvent, GenerationErrorEvent } from '@capgo/capacitor-llm';
 import { CapgoLLM } from '@capgo/capacitor-llm';
 import { marked } from 'marked';
 import { Capacitor } from '@capacitor/core';
@@ -449,6 +449,23 @@ const handleAiFinished = (event: AiFinishedEvent) => {
   isThinking.value = false;
 };
 
+const handleGenerationError = (event: GenerationErrorEvent) => {
+  if (event.chatId && event.chatId !== chatId.value) return;
+
+  const messageIndex = messages.value.findIndex(m => m.id === currentAiMessageId.value);
+  if (messageIndex !== -1) {
+    messages.value[messageIndex].text = `Sorry, I encountered an error. ${event.error}`;
+    messages.value[messageIndex].isComplete = true;
+  }
+
+  if (currentAiMessageId.value !== null) {
+    rawMessages.delete(currentAiMessageId.value);
+  }
+
+  currentAiMessageId.value = null;
+  isThinking.value = false;
+};
+
 const downloadModel = async (model: Model) => {
   if (!model.needsDownload || !model.url) return;
   
@@ -559,6 +576,7 @@ onMounted(async () => {
     // Set up listener for AI responses
     const textFromAiListener = await CapgoLLM.addListener('textFromAi', handleAiResponse);
     const aiFinishedListener = await CapgoLLM.addListener('aiFinished', handleAiFinished);
+    const generationErrorListener = await CapgoLLM.addListener('generationError', handleGenerationError);
     const downloadProgressListener = await CapgoLLM.addListener('downloadProgress', (event) => {
       downloadProgress.value = event.progress;
       console.log('Download progress:', event.progress);
@@ -566,6 +584,7 @@ onMounted(async () => {
     listenerRemove = async () => {
       await textFromAiListener.remove();
       await aiFinishedListener.remove();
+      await generationErrorListener.remove();
       await readinessListener.remove();
       await downloadProgressListener.remove();
     };

--- a/example-app/tests/unit/example.spec.ts
+++ b/example-app/tests/unit/example.spec.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vitest';
 describe('HomePage.vue', () => {
   test('renders home view', () => {
     const wrapper = mount(HomePage);
-    expect(wrapper.text()).toMatch('Inbox');
+    expect(wrapper.text()).toContain('LLM Chatbot');
+    expect(wrapper.text()).toContain('Model');
   });
 });

--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -51,6 +51,10 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
 
     #if COCOAPODS || canImport(MediaPipeTasksGenAI)
     private var llmInference: LlmInference?
+    private var mediaPipeChats: [String: LlmInference.Session] = [:]
+    private var mediaPipeTopk: Int = 40
+    private var mediaPipeTemperature: Float = 0.8
+    private var mediaPipeRandomSeed: Int = 0
     #endif
 
     @objc func setModel(_ call: CAPPluginCall) {
@@ -65,10 +69,15 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
         let maxTokens = call.getInt("maxTokens") ?? 2048
         let topk = call.getInt("topk") ?? 40
         let temperature = call.getFloat("temperature") ?? 0.8
+        let randomSeed = call.getInt("randomSeed") ?? 0
         let modelType = call.getString("modelType") // Optional model type parameter
 
         modelPath = path
         isReady = false
+        clearChatSessions()
+        #if COCOAPODS || canImport(MediaPipeTasksGenAI)
+        llmInference = nil
+        #endif
 
         // Check if user wants to use Apple Intelligence
         if path.lowercased() == "apple intelligence" {
@@ -138,6 +147,9 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
 
                 print("[CapgoLLM] Creating LlmInference instance with maxTokens: \(maxTokens), topk: \(topk), temperature: \(temperature)")
                 llmInference = try LlmInference(options: options)
+                mediaPipeTopk = topk
+                mediaPipeTemperature = temperature
+                mediaPipeRandomSeed = randomSeed
                 currentModelType = .mediaPipe
                 isReady = true
 
@@ -177,18 +189,23 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
 
         case .mediaPipe:
             #if COCOAPODS || canImport(MediaPipeTasksGenAI)
-            guard llmInference != nil else {
+            guard let inference = llmInference else {
                 print("[CapgoLLM] Error: Model not loaded when creating chat")
                 call.reject("Model not loaded")
                 return
             }
 
-            // MediaPipe doesn't use sessions, just return a dummy ID
-            let id = UUID().uuidString
-            print("[CapgoLLM] Created MediaPipe chat with ID: \(id)")
-            call.resolve([
-                "id": id
-            ])
+            do {
+                let session = try LlmInference.Session(llmInference: inference, options: makeMediaPipeSessionOptions())
+                let id = UUID().uuidString
+                mediaPipeChats[id] = session
+                print("[CapgoLLM] Created MediaPipe chat with ID: \(id)")
+                call.resolve([
+                    "id": id
+                ])
+            } catch {
+                call.reject("Failed to create chat: \(error.localizedDescription)")
+            }
             #else
             call.reject("MediaPipe is not available. Please install via CocoaPods.")
             #endif
@@ -263,12 +280,17 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
 
         case .mediaPipe:
             #if COCOAPODS || canImport(MediaPipeTasksGenAI)
-            guard let inference = llmInference else {
+            guard llmInference != nil else {
                 call.reject("Model not loaded")
                 return
             }
 
-            streamMediaPipeResponse(chatId: chatId, message: message, inference: inference, call: call)
+            guard let session = mediaPipeChats[chatId] else {
+                call.reject("chat not found")
+                return
+            }
+
+            streamMediaPipeResponse(chatId: chatId, message: message, session: session, call: call)
             #else
             call.reject("MediaPipe is not available. Please install via CocoaPods.")
             #endif
@@ -353,6 +375,15 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func getPluginVersion(_ call: CAPPluginCall) {
         call.resolve(["version": self.pluginVersion])
     }
+
+    private func clearChatSessions() {
+        #if canImport(FoundationModels)
+        appleChats.removeAll()
+        #endif
+        #if COCOAPODS || canImport(MediaPipeTasksGenAI)
+        mediaPipeChats.removeAll()
+        #endif
+    }
 }
 
 #if canImport(FoundationModels)
@@ -425,12 +456,20 @@ private extension LLMPlugin {
 
 #if COCOAPODS || canImport(MediaPipeTasksGenAI)
 private extension LLMPlugin {
-    func streamMediaPipeResponse(chatId: String, message: String, inference: LlmInference, call: CAPPluginCall) {
+    func makeMediaPipeSessionOptions() -> LlmInference.Session.Options {
+        let options = LlmInference.Session.Options()
+        options.topk = mediaPipeTopk
+        options.temperature = mediaPipeTemperature
+        options.randomSeed = mediaPipeRandomSeed
+        return options
+    }
+
+    func streamMediaPipeResponse(chatId: String, message: String, session: LlmInference.Session, call: CAPPluginCall) {
         Task {
             do {
                 print("[CapgoLLM] Attempting to generate streaming response for message: \(message)")
-
-                let resultStream = inference.generateResponseAsync(inputText: message)
+                try session.addQueryChunk(inputText: message)
+                let resultStream = session.generateResponseAsync()
 
                 for try await partialResult in resultStream {
                     print("[CapgoLLM] Partial result: \(partialResult)")

--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -275,95 +275,6 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-    #if canImport(FoundationModels)
-    @available(iOS 26.0, *)
-    private func validateAppleAvailability(model: SystemLanguageModel, call: CAPPluginCall) -> Bool {
-        switch model.availability {
-        case .available:
-            return true
-        case .unavailable(.deviceNotEligible):
-            call.reject("error deviceNotEligible error")
-        case .unavailable(.appleIntelligenceNotEnabled):
-            call.reject("error appleIntelligenceNotEnabled error")
-        case .unavailable(.modelNotReady):
-            call.reject("error modelNotReady error")
-        case .unavailable(let other):
-            call.reject("error \(other) error")
-        }
-
-        return false
-    }
-
-    @available(iOS 26.0, *)
-    private func streamAppleResponse(chatId: String, message: String, chat: LanguageModelSession, call: CAPPluginCall) {
-        Task {
-            do {
-                let stream = chat.streamResponse(to: message)
-                for try await chunk in stream {
-                    let textChunk = extractAppleTextChunk(from: chunk)
-                    notifyListeners("textFromAi", data: [
-                        "chatId": chatId,
-                        "text": textChunk,
-                        "isChunk": true
-                    ])
-                }
-                notifyListeners("aiFinished", data: ["chatId": chatId])
-                call.resolve()
-            } catch {
-                call.reject("Failed to get response: \(error.localizedDescription)")
-            }
-        }
-    }
-
-    @available(iOS 26.0, *)
-    private func extractAppleTextChunk(from chunk: Any) -> String {
-        let mirror = Mirror(reflecting: chunk)
-
-        if let contentProperty = mirror.children.first(where: { $0.label == "content" }),
-           let content = contentProperty.value as? String {
-            print("[CapgoLLM] Extracted content: \(content)")
-            return content
-        }
-
-        if let rawContentProperty = mirror.children.first(where: { $0.label == "rawContent" }),
-           let rawContent = rawContentProperty.value as? String {
-            print("[CapgoLLM] Extracted rawContent: \(rawContent)")
-            return rawContent
-        }
-
-        let fallback = "\(chunk)"
-        print("[CapgoLLM] Fallback to string conversion: \(fallback)")
-        return fallback
-    }
-    #endif
-
-    #if COCOAPODS || canImport(MediaPipeTasksGenAI)
-    private func streamMediaPipeResponse(chatId: String, message: String, inference: LlmInference, call: CAPPluginCall) {
-        Task {
-            do {
-                print("[CapgoLLM] Attempting to generate streaming response for message: \(message)")
-
-                let resultStream = inference.generateResponseAsync(inputText: message)
-
-                for try await partialResult in resultStream {
-                    print("[CapgoLLM] Partial result: \(partialResult)")
-                    notifyListeners("textFromAi", data: [
-                        "chatId": chatId,
-                        "text": partialResult,
-                        "isChunk": true
-                    ])
-                }
-
-                notifyListeners("aiFinished", data: ["chatId": chatId])
-                call.resolve()
-            } catch {
-                print("[CapgoLLM] Error details: \(error)")
-                call.reject("Failed to generate response: \(error.localizedDescription)")
-            }
-        }
-    }
-    #endif
-
     @objc func downloadModel(_ call: CAPPluginCall) {
         guard let urlString = call.getString("url") else {
             call.reject("URL is required")
@@ -443,6 +354,107 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
         call.resolve(["version": self.pluginVersion])
     }
 }
+
+#if canImport(FoundationModels)
+private extension LLMPlugin {
+    @available(iOS 26.0, *)
+    func validateAppleAvailability(model: SystemLanguageModel, call: CAPPluginCall) -> Bool {
+        switch model.availability {
+        case .available:
+            return true
+        case .unavailable(.deviceNotEligible):
+            call.reject("error deviceNotEligible error")
+        case .unavailable(.appleIntelligenceNotEnabled):
+            call.reject("error appleIntelligenceNotEnabled error")
+        case .unavailable(.modelNotReady):
+            call.reject("error modelNotReady error")
+        case .unavailable(let other):
+            call.reject("error \(other) error")
+        }
+
+        return false
+    }
+
+    @available(iOS 26.0, *)
+    func streamAppleResponse(chatId: String, message: String, chat: LanguageModelSession, call: CAPPluginCall) {
+        Task {
+            do {
+                let stream = chat.streamResponse(to: message)
+                for try await chunk in stream {
+                    let textChunk = extractAppleTextChunk(from: chunk)
+                    notifyListeners("textFromAi", data: [
+                        "chatId": chatId,
+                        "text": textChunk,
+                        "isChunk": true
+                    ])
+                }
+                notifyListeners("aiFinished", data: ["chatId": chatId])
+                call.resolve()
+            } catch {
+                notifyListeners("generationError", data: [
+                    "chatId": chatId,
+                    "error": error.localizedDescription
+                ])
+                call.reject("Failed to get response: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @available(iOS 26.0, *)
+    func extractAppleTextChunk(from chunk: Any) -> String {
+        let mirror = Mirror(reflecting: chunk)
+
+        if let contentProperty = mirror.children.first(where: { $0.label == "content" }),
+           let content = contentProperty.value as? String {
+            print("[CapgoLLM] Extracted content: \(content)")
+            return content
+        }
+
+        if let rawContentProperty = mirror.children.first(where: { $0.label == "rawContent" }),
+           let rawContent = rawContentProperty.value as? String {
+            print("[CapgoLLM] Extracted rawContent: \(rawContent)")
+            return rawContent
+        }
+
+        let fallback = "\(chunk)"
+        print("[CapgoLLM] Fallback to string conversion: \(fallback)")
+        return fallback
+    }
+}
+#endif
+
+#if COCOAPODS || canImport(MediaPipeTasksGenAI)
+private extension LLMPlugin {
+    func streamMediaPipeResponse(chatId: String, message: String, inference: LlmInference, call: CAPPluginCall) {
+        Task {
+            do {
+                print("[CapgoLLM] Attempting to generate streaming response for message: \(message)")
+
+                let resultStream = inference.generateResponseAsync(inputText: message)
+
+                for try await partialResult in resultStream {
+                    print("[CapgoLLM] Partial result: \(partialResult)")
+                    notifyListeners("textFromAi", data: [
+                        "chatId": chatId,
+                        "text": partialResult,
+                        "isChunk": true
+                    ])
+                }
+
+                notifyListeners("aiFinished", data: ["chatId": chatId])
+                call.resolve()
+            } catch {
+                print("[CapgoLLM] Error details: \(error)")
+                notifyListeners("generationError", data: [
+                    "chatId": chatId,
+                    "error": error.localizedDescription
+                ])
+                call.reject("Failed to generate response: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+#endif
 
 // Download delegate class to handle progress updates
 class DownloadDelegate: NSObject, URLSessionDownloadDelegate {

--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -124,8 +124,8 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
                         if companionPath == nil {
                             print("[CapgoLLM] Warning: Companion .litertlm file not found for \(fileName)")
                             // Don't fail here as some models might not need it
-                        } else {
-                            print("[CapgoLLM] Found companion file at path: \(companionPath!)")
+                        } else if let companionPath {
+                            print("[CapgoLLM] Found companion file at path: \(companionPath)")
                         }
                     }
                 }
@@ -242,23 +242,7 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
         case .appleIntelligence:
             #if canImport(FoundationModels)
             if #available(iOS 26.0, *), let model = appleModel as? SystemLanguageModel {
-                switch model.availability {
-                case .available:
-                    break
-                case .unavailable(.deviceNotEligible):
-                    call.reject("error deviceNotEligible error")
-                    return
-                case .unavailable(.appleIntelligenceNotEnabled):
-                    call.reject("error appleIntelligenceNotEnabled error")
-                    return
-                case .unavailable(.modelNotReady):
-                    call.reject("error modelNotReady error")
-                    return
-                case .unavailable(let other):
-                    call.reject("error \(other) error")
-                    return
-                }
-
+                guard validateAppleAvailability(model: model, call: call) else { return }
                 guard let chat = appleChats[chatId] as? LanguageModelSession else {
                     call.reject("chat not found")
                     return
@@ -269,47 +253,7 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
                     return
                 }
 
-                Task {
-                    do {
-                        let stream = chat.streamResponse(to: message)
-                        for try await chunk in stream {
-                            print("[CapgoLLM] Chunk type: \(type(of: chunk))")
-
-                            // Extract content from Snapshot object using Mirror reflection
-                            let textChunk: String
-                            let mirror = Mirror(reflecting: chunk)
-
-                            // Try to find content property
-                            if let contentProperty = mirror.children.first(where: { $0.label == "content" }),
-                               let content = contentProperty.value as? String {
-                                textChunk = content
-                                print("[CapgoLLM] Extracted content: \(content)")
-                            } else {
-                                // Fallback: try rawContent
-                                if let rawContentProperty = mirror.children.first(where: { $0.label == "rawContent" }),
-                                   let rawContent = rawContentProperty.value as? String {
-                                    textChunk = rawContent
-                                    print("[CapgoLLM] Extracted rawContent: \(rawContent)")
-                                } else {
-                                    // Final fallback
-                                    textChunk = "\(chunk)"
-                                    print("[CapgoLLM] Fallback to string conversion: \(textChunk)")
-                                }
-                            }
-                            let data: [String: Any] = [
-                                "chatId": chatId as String,
-                                "text": textChunk as String,
-                                "isChunk": true
-                            ]
-                            self.notifyListeners("textFromAi", data: data)
-                        }
-                        let finishData: [String: Any] = ["chatId": chatId as String]
-                        self.notifyListeners("aiFinished", data: finishData)
-                        call.resolve()
-                    } catch {
-                        call.reject("Failed to get response: \(error.localizedDescription)")
-                    }
-                }
+                streamAppleResponse(chatId: chatId, message: message, chat: chat, call: call)
             } else {
                 call.reject("Apple Intelligence requires iOS 26.0 or later")
             }
@@ -324,44 +268,101 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
                 return
             }
 
-            Task {
-                do {
-                    print("[CapgoLLM] Attempting to generate streaming response for message: \(message)")
-
-                    // Use native streaming API
-                    let resultStream = inference.generateResponseAsync(inputText: message)
-
-                    var fullResponse = ""
-
-                    for try await partialResult in resultStream {
-                        print("[CapgoLLM] Partial result: \(partialResult)")
-
-                        // Send the chunk
-                        self.notifyListeners("textFromAi", data: [
-                            "chatId": chatId,
-                            "text": partialResult,
-                            "isChunk": true
-                        ])
-
-                        // Accumulate for history (if needed)
-                        fullResponse += partialResult
-                    }
-
-                    print("[CapgoLLM] Streaming complete. Full response: \(fullResponse)")
-
-                    self.notifyListeners("aiFinished", data: ["chatId": chatId])
-                    call.resolve()
-
-                } catch {
-                    print("[CapgoLLM] Error details: \(error)")
-                    call.reject("Failed to generate response: \(error.localizedDescription)")
-                }
-            }
+            streamMediaPipeResponse(chatId: chatId, message: message, inference: inference, call: call)
             #else
             call.reject("MediaPipe is not available. Please install via CocoaPods.")
             #endif
         }
     }
+
+    #if canImport(FoundationModels)
+    @available(iOS 26.0, *)
+    private func validateAppleAvailability(model: SystemLanguageModel, call: CAPPluginCall) -> Bool {
+        switch model.availability {
+        case .available:
+            return true
+        case .unavailable(.deviceNotEligible):
+            call.reject("error deviceNotEligible error")
+        case .unavailable(.appleIntelligenceNotEnabled):
+            call.reject("error appleIntelligenceNotEnabled error")
+        case .unavailable(.modelNotReady):
+            call.reject("error modelNotReady error")
+        case .unavailable(let other):
+            call.reject("error \(other) error")
+        }
+
+        return false
+    }
+
+    @available(iOS 26.0, *)
+    private func streamAppleResponse(chatId: String, message: String, chat: LanguageModelSession, call: CAPPluginCall) {
+        Task {
+            do {
+                let stream = chat.streamResponse(to: message)
+                for try await chunk in stream {
+                    let textChunk = extractAppleTextChunk(from: chunk)
+                    notifyListeners("textFromAi", data: [
+                        "chatId": chatId,
+                        "text": textChunk,
+                        "isChunk": true
+                    ])
+                }
+                notifyListeners("aiFinished", data: ["chatId": chatId])
+                call.resolve()
+            } catch {
+                call.reject("Failed to get response: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func extractAppleTextChunk(from chunk: Any) -> String {
+        let mirror = Mirror(reflecting: chunk)
+
+        if let contentProperty = mirror.children.first(where: { $0.label == "content" }),
+           let content = contentProperty.value as? String {
+            print("[CapgoLLM] Extracted content: \(content)")
+            return content
+        }
+
+        if let rawContentProperty = mirror.children.first(where: { $0.label == "rawContent" }),
+           let rawContent = rawContentProperty.value as? String {
+            print("[CapgoLLM] Extracted rawContent: \(rawContent)")
+            return rawContent
+        }
+
+        let fallback = "\(chunk)"
+        print("[CapgoLLM] Fallback to string conversion: \(fallback)")
+        return fallback
+    }
+    #endif
+
+    #if COCOAPODS || canImport(MediaPipeTasksGenAI)
+    private func streamMediaPipeResponse(chatId: String, message: String, inference: LlmInference, call: CAPPluginCall) {
+        Task {
+            do {
+                print("[CapgoLLM] Attempting to generate streaming response for message: \(message)")
+
+                let resultStream = inference.generateResponseAsync(inputText: message)
+
+                for try await partialResult in resultStream {
+                    print("[CapgoLLM] Partial result: \(partialResult)")
+                    notifyListeners("textFromAi", data: [
+                        "chatId": chatId,
+                        "text": partialResult,
+                        "isChunk": true
+                    ])
+                }
+
+                notifyListeners("aiFinished", data: ["chatId": chatId])
+                call.resolve()
+            } catch {
+                print("[CapgoLLM] Error details: \(error)")
+                call.reject("Failed to generate response: \(error.localizedDescription)")
+            }
+        }
+    }
+    #endif
 
     @objc func downloadModel(_ call: CAPPluginCall) {
         guard let urlString = call.getString("url") else {
@@ -386,9 +387,7 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
 
         // Create download task
         let session = URLSession(configuration: .default, delegate: DownloadDelegate(plugin: self), delegateQueue: nil)
-        let downloadTask = session.downloadTask(with: url) { [weak self] (tempURL, _, error) in
-            guard let self = self else { return }
-
+        let downloadTask = session.downloadTask(with: url) { tempURL, _, error in
             if let error = error {
                 call.reject("Download failed: \(error.localizedDescription)")
                 return

--- a/package.json
+++ b/package.json
@@ -32,9 +32,12 @@
     "llm",
     "local",
     "gemma",
+    "gemma4",
     "gemma3",
     "gemma3-270m",
     "gemma2-2b",
+    "litert",
+    "litert-lm",
     "apple-intelligence",
     "gpt"
   ],

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -23,9 +23,9 @@ export interface LLMPlugin {
 
   /**
    * Sets the model configuration
-   * - iOS: Use "Apple Intelligence" as path for the system model, or provide a MediaPipe custom model
+   * - iOS: Use "Apple Intelligence" as path for the system model, or provide a downloaded custom model bundle such as Gemma 4 `.litertlm`
    * - Android: Prefer LiteRT-LM `.litertlm` bundles; legacy MediaPipe `.task` models are still supported
-   * - Web: Provide a MediaPipe `.task` model
+   * - Web: Provide a web-ready model asset for `@mediapipe/tasks-genai` such as Gemma 4 `*-web.task`
    * @param options - The model configuration
    * @returns Promise that resolves when model is loaded
    */
@@ -189,7 +189,7 @@ export interface ReadinessChangeEvent {
  * Only `path` is required. All other properties are optional overrides.
  */
 export interface ModelOptions {
-  /** Model path or "Apple Intelligence" for the Apple system model on iOS */
+  /** Model path or "Apple Intelligence" for the Apple system model on iOS. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. */
   path: string;
   /** Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. */
   modelType?: string;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -132,9 +132,10 @@ export interface AiFinishedEvent {
 
 /**
  * Event data for generation failures
+ * `chatId` is optional and may be omitted when the failure is not tied to a specific chat.
  */
 export interface GenerationErrorEvent {
-  /** The chat session ID that failed, when available */
+  /** Optional. The chat session ID that failed, when available. */
   chatId?: string;
   /** Error message describing the failure */
   error: string;
@@ -142,6 +143,7 @@ export interface GenerationErrorEvent {
 
 /**
  * Options for downloading a model
+ * Only `url` is required. `companionUrl` and `filename` are optional.
  */
 export interface DownloadModelOptions {
   /** URL of the model file to download */
@@ -184,11 +186,12 @@ export interface ReadinessChangeEvent {
 
 /**
  * Model configuration options
+ * Only `path` is required. All other properties are optional overrides.
  */
 export interface ModelOptions {
-  /** Model path or "Apple Intelligence" for the iOS system model */
+  /** Model path or "Apple Intelligence" for the Apple system model on iOS */
   path: string;
-  /** Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. */
+  /** Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. */
   modelType?: string;
   /** Maximum number of tokens the model handles */
   maxTokens?: number;
@@ -196,6 +199,6 @@ export interface ModelOptions {
   topk?: number;
   /** Amount of randomness in generation (0.0-1.0) */
   temperature?: number;
-  /** Random seed for generation */
+  /** Optional. Random seed for generation. */
   randomSeed?: number;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -23,8 +23,9 @@ export interface LLMPlugin {
 
   /**
    * Sets the model configuration
-   * - iOS: Use "Apple Intelligence" as path for system model, or provide path to MediaPipe model
-   * - Android: Path to a MediaPipe model file (in assets or files directory)
+   * - iOS: Use "Apple Intelligence" as path for the system model, or provide a MediaPipe custom model
+   * - Android: Prefer LiteRT-LM `.litertlm` bundles; legacy MediaPipe `.task` models are still supported
+   * - Web: Provide a MediaPipe `.task` model
    * @param options - The model configuration
    * @returns Promise that resolves when model is loaded
    */
@@ -124,7 +125,7 @@ export interface AiFinishedEvent {
 export interface DownloadModelOptions {
   /** URL of the model file to download */
   url: string;
-  /** Optional: URL of companion file (e.g., .litertlm for Android) */
+  /** Optional: URL of a companion file for legacy model formats */
   companionUrl?: string;
   /** Optional: Custom filename (defaults to filename from URL) */
   filename?: string;
@@ -164,9 +165,9 @@ export interface ReadinessChangeEvent {
  * Model configuration options
  */
 export interface ModelOptions {
-  /** Model path or "Apple Intelligence" for iOS system model */
+  /** Model path or "Apple Intelligence" for the iOS system model */
   path: string;
-  /** Model file type/extension (e.g., "task", "bin", "litertlm"). If not provided, will be extracted from path. */
+  /** Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. */
   modelType?: string;
   /** Maximum number of tokens the model handles */
   maxTokens?: number;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -63,6 +63,17 @@ export interface LLMPlugin {
   ): Promise<{ remove: () => Promise<void> }>;
 
   /**
+   * Adds a listener for generation failures that happen after streaming starts
+   * @param eventName - Event name 'generationError'
+   * @param listenerFunc - Callback function for generation errors
+   * @returns Promise with remove function to unsubscribe
+   */
+  addListener(
+    eventName: 'generationError',
+    listenerFunc: (event: GenerationErrorEvent) => void,
+  ): Promise<{ remove: () => Promise<void> }>;
+
+  /**
    * Adds a listener for model download progress events
    * @param eventName - Event name 'downloadProgress'
    * @param listenerFunc - Callback function for progress events
@@ -117,6 +128,16 @@ export interface TextFromAiEvent {
 export interface AiFinishedEvent {
   /** The chat session ID that finished */
   chatId: string;
+}
+
+/**
+ * Event data for generation failures
+ */
+export interface GenerationErrorEvent {
+  /** The chat session ID that failed, when available */
+  chatId?: string;
+  /** Error message describing the failure */
+  error: string;
 }
 
 /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -54,11 +54,14 @@ export class CapgoLLMWeb extends WebPlugin implements LLMPlugin {
       throw new Error(`Chat session ${options.chatId} is not active`);
     }
 
+    let hasStreamed = false;
+
     try {
       // Generate response using MediaPipe GenAI streaming API
       const response = session.llm.generateResponseStream(options.message);
 
       for await (const partialResponse of response) {
+        hasStreamed = true;
         // Send incremental text
         this.notifyListeners('textFromAi', {
           text: partialResponse,
@@ -73,10 +76,15 @@ export class CapgoLLMWeb extends WebPlugin implements LLMPlugin {
       } as AiFinishedEvent);
     } catch (error) {
       console.error('Error generating response:', error);
-      this.notifyListeners('generationError', {
-        chatId: options.chatId,
-        error: error instanceof Error ? error.message : String(error),
-      } as GenerationErrorEvent);
+      const message = error instanceof Error ? error.message : String(error);
+      if (hasStreamed) {
+        this.notifyListeners('generationError', {
+          chatId: options.chatId,
+          error: message,
+        } as GenerationErrorEvent);
+        return;
+      }
+
       throw error;
     }
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -13,16 +13,26 @@ import type {
   ReadinessChangeEvent,
 } from './definitions';
 
+interface ChatTurn {
+  role: 'user' | 'model';
+  content: string;
+}
+
 interface ChatSession {
   id: string;
-  llm: any;
+  llm: LlmInference;
   isActive: boolean;
+  modelPath: string;
+  modelType: string;
+  history: ChatTurn[];
 }
 
 export class CapgoLLMWeb extends WebPlugin implements LLMPlugin {
-  private llm: any = null;
+  private llm: LlmInference | null = null;
   private chatSessions: Map<string, ChatSession> = new Map();
   private readiness = 'not-loaded';
+  private modelPath = '';
+  private modelType = 'task';
 
   async getReadiness(): Promise<{ readiness: string }> {
     return { readiness: this.readiness };
@@ -39,6 +49,9 @@ export class CapgoLLMWeb extends WebPlugin implements LLMPlugin {
       id: chatId,
       llm: this.llm,
       isActive: true,
+      modelPath: this.modelPath,
+      modelType: this.modelType,
+      history: [],
     });
 
     return { id: chatId };
@@ -55,20 +68,39 @@ export class CapgoLLMWeb extends WebPlugin implements LLMPlugin {
     }
 
     let hasStreamed = false;
+    let responseText = '';
 
     try {
-      // Generate response using MediaPipe GenAI streaming API
-      const response = session.llm.generateResponseStream(options.message);
+      const prompt = this.buildPrompt(session, options.message);
 
-      for await (const partialResponse of response) {
+      const finalResponse = await session.llm.generateResponse(prompt, (partialResponse, done) => {
+        if (done || !partialResponse) {
+          return;
+        }
+
         hasStreamed = true;
-        // Send incremental text
+        responseText += partialResponse;
+
         this.notifyListeners('textFromAi', {
           text: partialResponse,
           chatId: options.chatId,
           isChunk: true,
         } as TextFromAiEvent);
+      });
+
+      if (!hasStreamed && finalResponse) {
+        responseText = finalResponse;
+        this.notifyListeners('textFromAi', {
+          text: finalResponse,
+          chatId: options.chatId,
+          isChunk: true,
+        } as TextFromAiEvent);
       }
+
+      session.history.push(
+        { role: 'user', content: options.message },
+        { role: 'model', content: responseText || finalResponse },
+      );
 
       // Notify completion
       this.notifyListeners('aiFinished', {
@@ -91,6 +123,8 @@ export class CapgoLLMWeb extends WebPlugin implements LLMPlugin {
 
   async setModel(options: ModelOptions): Promise<void> {
     try {
+      this.closeCurrentModel();
+
       // Update readiness
       this.readiness = 'loading';
       this.notifyListeners('readinessChange', { readiness: this.readiness } as ReadinessChangeEvent);
@@ -111,11 +145,15 @@ export class CapgoLLMWeb extends WebPlugin implements LLMPlugin {
       );
       // Create LLM instance
       this.llm = await LlmInference.createFromOptions(genai, config);
+      this.modelPath = options.path;
+      this.modelType = this.resolveModelType(options);
+      this.chatSessions.clear();
 
       // Update readiness
       this.readiness = 'ready';
       this.notifyListeners('readinessChange', { readiness: this.readiness } as ReadinessChangeEvent);
     } catch (error) {
+      this.closeCurrentModel();
       this.readiness = 'error';
       this.notifyListeners('readinessChange', { readiness: this.readiness } as ReadinessChangeEvent);
       throw error;
@@ -188,5 +226,37 @@ export class CapgoLLMWeb extends WebPlugin implements LLMPlugin {
 
   async getPluginVersion(): Promise<{ version: string }> {
     return { version: 'web' };
+  }
+
+  private closeCurrentModel(): void {
+    this.chatSessions.clear();
+    this.llm?.close();
+    this.llm = null;
+    this.modelPath = '';
+    this.modelType = 'task';
+  }
+
+  private resolveModelType(options: ModelOptions): string {
+    if (options.modelType?.trim()) {
+      return options.modelType.trim().toLowerCase();
+    }
+
+    const extension = options.path.split('.').pop();
+    return extension ? extension.toLowerCase() : 'task';
+  }
+
+  private buildPrompt(session: ChatSession, message: string): string {
+    if (!this.usesGemmaChatTemplate(session)) {
+      return message;
+    }
+
+    const history = [...session.history, { role: 'user' as const, content: message }];
+    return `${history
+      .map((turn) => `<start_of_turn>${turn.role}\n${turn.content}<end_of_turn>`)
+      .join('\n')}\n<start_of_turn>model\n`;
+  }
+
+  private usesGemmaChatTemplate(session: ChatSession): boolean {
+    return /gemma/i.test(session.modelPath) || session.modelType === 'litertlm';
   }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -8,6 +8,7 @@ import type {
   ModelOptions,
   TextFromAiEvent,
   AiFinishedEvent,
+  GenerationErrorEvent,
   DownloadProgressEvent,
   ReadinessChangeEvent,
 } from './definitions';
@@ -72,6 +73,10 @@ export class CapgoLLMWeb extends WebPlugin implements LLMPlugin {
       } as AiFinishedEvent);
     } catch (error) {
       console.error('Error generating response:', error);
+      this.notifyListeners('generationError', {
+        chatId: options.chatId,
+        error: error instanceof Error ? error.message : String(error),
+      } as GenerationErrorEvent);
       throw error;
     }
   }


### PR DESCRIPTION
## What
- migrate the Android backend to LiteRT-LM for `.litertlm` models while keeping a MediaPipe fallback for legacy `.task` files
- refresh the README and TypeScript docs around the new Android model flow
- update the example app to showcase Gemma 4 LiteRT-LM downloads on Android and keep Apple Intelligence as the iOS default
- fix the stale example unit test so it matches the current LLM home screen

## Why
- MediaPipe LLM Inference is deprecated on Android and iOS, and Android now has an official LiteRT-LM path
- the repo examples were still centered on old Gemma 3 placeholder URLs and `.task` expectations
- keeping the legacy Android fallback avoids breaking existing consumers while moving new integrations onto LiteRT-LM

## How
- added `com.google.ai.edge.litertlm:litertlm-android:0.10.0` and rewrote the Android model loader/chat flow to route `.litertlm` models through LiteRT-LM conversations
- preserved legacy Android `.task` handling through the existing MediaPipe path so old assets still load
- tightened Android plugin error handling so invalid chat/model state rejects synchronously instead of resolving and failing later
- rewrote the docs and example app model picker around real Gemma 4 E2B/E4B LiteRT-LM downloads from `litert-community`
- split the long iOS `sendMessage` implementation into helpers so the repo lint gate stays green
- prepared with Codex

## Testing
- `bun run lint`
- `bun run check:wiring`
- `bun run verify`
- `cd example-app && bun install && bun run build`
- `cd example-app && bun run test:unit -- --run`

## Not Tested
- end-to-end inference on physical iOS or Android devices with a downloaded Gemma 4 model
- PR CI and automated review comments after opening this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clarified platform defaults (iOS Apple Intelligence, Android LiteRT‑LM preference, Web MediaPipe) and added a generationError event/listener.

* **Bug Fixes**
  * Improved readiness states, unified streaming/error propagation, and more robust generation-error reporting.

* **Documentation**
  * Streamlined README and example-app docs with concise model-setup examples and updated platform guidance.

* **Refactor**
  * Consolidated backend selection, model-loading and streaming flows; simplified example app UI and model catalog.

* **Tests**
  * Updated HomePage unit test expectations.

* **Chores**
  * Added Android runtime support for the LiteRT‑LM model flow and updated package keywords.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->