### PR TITLE
[codex] Document app-side ExecuTorch linking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,21 +3,28 @@ import PackageDescription
 
 let package = Package(
     name: "CapgoCapacitorLlm",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v17)],
     products: [
         .library(
             name: "CapgoCapacitorLlm",
             targets: ["LLMPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
+        .package(url: "https://github.com/pytorch/executorch.git", branch: "swiftpm-1.2.0")
     ],
     targets: [
         .target(
             name: "LLMPlugin",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "executorch_llm", package: "executorch"),
+                .product(name: "backend_xnnpack", package: "executorch"),
+                .product(name: "kernels_llm", package: "executorch"),
+                .product(name: "kernels_optimized", package: "executorch"),
+                .product(name: "kernels_quantized", package: "executorch"),
+                .product(name: "kernels_torchao", package: "executorch")
             ],
             path: "ios/Sources/LLMPlugin"),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -3,28 +3,21 @@ import PackageDescription
 
 let package = Package(
     name: "CapgoCapacitorLlm",
-    platforms: [.iOS(.v17)],
+    platforms: [.iOS(.v15)],
     products: [
         .library(
             name: "CapgoCapacitorLlm",
             targets: ["LLMPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(url: "https://github.com/pytorch/executorch.git", branch: "swiftpm-1.2.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0")
     ],
     targets: [
         .target(
             name: "LLMPlugin",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm"),
-                .product(name: "executorch_llm", package: "executorch"),
-                .product(name: "backend_xnnpack", package: "executorch"),
-                .product(name: "kernels_llm", package: "executorch"),
-                .product(name: "kernels_optimized", package: "executorch"),
-                .product(name: "kernels_quantized", package: "executorch"),
-                .product(name: "kernels_torchao", package: "executorch")
+                .product(name: "Cordova", package: "capacitor-swift-pm")
             ],
             path: "ios/Sources/LLMPlugin"),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ bunx cap sync
 
 ### iOS Additional Setup for Custom Models
 
-Apple Intelligence works without bundled model files on supported iOS versions. For custom models, the plugin supports MediaPipe through CocoaPods and ExecuTorch through Swift Package Manager.
+Apple Intelligence works without bundled model files on supported iOS versions. For custom models, the plugin supports MediaPipe through CocoaPods and ExecuTorch through Swift Package Manager. CocoaPods remains iOS 15 compatible; Swift Package Manager requires iOS 17 because it links ExecuTorch.
 
 **Using CocoaPods:**
 The MediaPipe dependencies are already configured in the podspec. Make sure to run `pod install` after adding the plugin.
 
-ExecuTorch is not provided by the CocoaPods integration. CocoaPods installs MediaPipe only. If your iOS app uses `engine: 'executorch'`, you must also add the ExecuTorch Swift Package products to the app target; otherwise the plugin rejects `setModel` with a clear runtime error.
+ExecuTorch is not provided by the CocoaPods integration. CocoaPods installs MediaPipe only. CocoaPods builds reject `engine: 'executorch'` with a clear runtime error; use the Swift Package Manager integration for iOS ExecuTorch.
 
 **Note about Static Framework Warning:**
 When running `pod install`, you may see a warning about transitive dependencies with statically linked binaries. To fix this, update your Podfile:
@@ -75,7 +75,7 @@ end
 ```
 
 **Using Swift Package Manager:**
-The main Swift package stays compatible with iOS 15. To use ExecuTorch `.pte` models on iOS, add the ExecuTorch Swift package to your app target and link `executorch_llm`, `backend_xnnpack`, `kernels_llm`, `kernels_optimized`, `kernels_quantized`, and `kernels_torchao`. ExecuTorch currently requires iOS 17 or newer in the app target that links it. MediaPipe GenAI still does not officially support SPM, so use CocoaPods for MediaPipe `.task` models.
+The Swift Package Manager integration requires iOS 17 or newer and links the official ExecuTorch SwiftPM package branch `swiftpm-1.2.0` with `executorch_llm`, `backend_xnnpack`, `kernels_llm`, `kernels_optimized`, `kernels_quantized`, and `kernels_torchao`. MediaPipe GenAI still does not officially support SPM, so use CocoaPods for MediaPipe `.task` models.
 
 ## Adding a Model to Your App
 
@@ -83,7 +83,7 @@ The simplest cross-platform custom model path is ExecuTorch. It uses the same ki
 
 ### ExecuTorch Models (iOS and Android)
 
-iOS uses ExecuTorch only when the app target links the ExecuTorch SwiftPM products. It is not included by CocoaPods, so a CocoaPods-only iOS install can use Apple Intelligence or MediaPipe but will refuse `engine: 'executorch'`. Android uses the ExecuTorch Maven package.
+iOS uses ExecuTorch through the Swift Package Manager integration. It is not included by CocoaPods, so a CocoaPods-only iOS install can use Apple Intelligence or MediaPipe but will refuse `engine: 'executorch'`. Android uses the ExecuTorch Maven package.
 
 Bundle the model files:
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ bunx cap sync
 
 ### iOS Additional Setup for Custom Models
 
-Apple Intelligence works without bundled model files on supported iOS versions. For custom models, the plugin supports MediaPipe through CocoaPods and ExecuTorch through Swift Package Manager. CocoaPods remains iOS 15 compatible; Swift Package Manager requires iOS 17 because it links ExecuTorch.
+Apple Intelligence works without bundled model files on supported iOS versions. For custom models, the plugin supports MediaPipe through CocoaPods and ExecuTorch when the host app links ExecuTorch with Swift Package Manager. The plugin package remains iOS 15 compatible; iOS ExecuTorch requires an iOS 17 or newer app target because ExecuTorch requires iOS 17.
 
 **Using CocoaPods:**
 The MediaPipe dependencies are already configured in the podspec. Make sure to run `pod install` after adding the plugin.
 
-ExecuTorch is not provided by the CocoaPods integration. CocoaPods installs MediaPipe only. CocoaPods builds reject `engine: 'executorch'` with a clear runtime error; use the Swift Package Manager integration for iOS ExecuTorch.
+ExecuTorch is not provided by the CocoaPods integration. CocoaPods installs MediaPipe only. CocoaPods builds reject `engine: 'executorch'` with a clear runtime error unless the app also links ExecuTorch separately.
 
 **Note about Static Framework Warning:**
 When running `pod install`, you may see a warning about transitive dependencies with statically linked binaries. To fix this, update your Podfile:
@@ -75,7 +75,17 @@ end
 ```
 
 **Using Swift Package Manager:**
-The Swift Package Manager integration requires iOS 17 or newer and links the official ExecuTorch SwiftPM package branch `swiftpm-1.2.0` with `executorch_llm`, `backend_xnnpack`, `kernels_llm`, `kernels_optimized`, `kernels_quantized`, and `kernels_torchao`. MediaPipe GenAI still does not officially support SPM, so use CocoaPods for MediaPipe `.task` models.
+The plugin's `Package.swift` does not link ExecuTorch directly because that would force every Swift Package Manager user onto iOS 17 or newer, even when they only use Apple Intelligence or MediaPipe.
+
+To use ExecuTorch on iOS, add it to your app target:
+
+1. Set the app target deployment version to iOS 17 or newer.
+2. In Xcode, open the app project, select **Package Dependencies**, and add `https://github.com/pytorch/executorch.git`.
+3. Use the `swiftpm-1.2.0` branch, or the ExecuTorch branch that matches the runtime version you want.
+4. Add these products to the app target: `executorch_llm`, `backend_xnnpack`, `kernels_llm`, `kernels_optimized`, `kernels_quantized`, and `kernels_torchao`.
+5. Add the `.pte` model and tokenizer file to the app target's Copy Bundle Resources, or download them at runtime.
+
+If those ExecuTorch products are not linked into the app target, `setModel({ engine: 'executorch' })` rejects with a clear runtime error. MediaPipe GenAI still does not officially support SPM, so use CocoaPods for MediaPipe `.task` models.
 
 ## Adding a Model to Your App
 
@@ -83,7 +93,7 @@ The simplest cross-platform custom model path is ExecuTorch. It uses the same ki
 
 ### ExecuTorch Models (iOS and Android)
 
-iOS uses ExecuTorch through the Swift Package Manager integration. It is not included by CocoaPods, so a CocoaPods-only iOS install can use Apple Intelligence or MediaPipe but will refuse `engine: 'executorch'`. Android uses the ExecuTorch Maven package.
+iOS uses ExecuTorch only when the host app links the ExecuTorch Swift Package products. It is not included by CocoaPods or by the plugin's `Package.swift`, so an app without those products can use Apple Intelligence or MediaPipe but will refuse `engine: 'executorch'`. Android uses the ExecuTorch Maven package.
 
 Bundle the model files:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Apple Intelligence works without bundled model files on supported iOS versions. 
 **Using CocoaPods:**
 The MediaPipe dependencies are already configured in the podspec. Make sure to run `pod install` after adding the plugin.
 
+ExecuTorch is not provided by the CocoaPods integration. CocoaPods installs MediaPipe only. If your iOS app uses `engine: 'executorch'`, you must also add the ExecuTorch Swift Package products to the app target; otherwise the plugin rejects `setModel` with a clear runtime error.
+
 **Note about Static Framework Warning:**
 When running `pod install`, you may see a warning about transitive dependencies with statically linked binaries. To fix this, update your Podfile:
 
@@ -81,7 +83,7 @@ The simplest cross-platform custom model path is ExecuTorch. It uses the same ki
 
 ### ExecuTorch Models (iOS and Android)
 
-iOS uses ExecuTorch when the app target links the ExecuTorch SwiftPM products. Android uses the ExecuTorch Maven package.
+iOS uses ExecuTorch only when the app target links the ExecuTorch SwiftPM products. It is not included by CocoaPods, so a CocoaPods-only iOS install can use Apple Intelligence or MediaPipe but will refuse `engine: 'executorch'`. Android uses the ExecuTorch Maven package.
 
 Bundle the model files:
 

--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -10,6 +10,9 @@ import FoundationModels
 #if canImport(MediaPipeTasksGenAI) && !targetEnvironment(macCatalyst)
 import MediaPipeTasksGenAI
 #endif
+#if canImport(ExecuTorchLLM)
+import ExecuTorchLLM
+#endif
 
 /**
  * Please read the Capacitor iOS Plugin Development Guide
@@ -78,10 +81,18 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
     private var execuTorchRunner: DynamicExecuTorchRunner?
     private var execuTorchChats: [String: ExecuTorchChatSession] = [:]
     private let execuTorchGenerationLock = NSLock()
-    private let execuTorchNotLinkedMessage = "ExecuTorch is not linked in this iOS app. " +
-        "It is not installed by CocoaPods; add the ExecuTorch Swift Package products " +
-        "to the app target on iOS 17+ or choose another engine."
+    private let execuTorchNotLinkedMessage = "ExecuTorch is not available in this iOS build. " +
+        "It is not installed by CocoaPods; use the Swift Package Manager integration " +
+        "on iOS 17+ or choose another engine."
     private var execuTorchIsGenerating = false
+
+    private var isExecuTorchRuntimeAvailable: Bool {
+        #if canImport(ExecuTorchLLM)
+        return DynamicExecuTorchRunner.isAvailable
+        #else
+        return false
+        #endif
+    }
 
     @objc func setModel(_ call: CAPPluginCall) {
         guard let path = call.getString("path") else {
@@ -259,7 +270,7 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        guard DynamicExecuTorchRunner.isAvailable else {
+        guard isExecuTorchRuntimeAvailable else {
             isReady = false
             notifyListeners("readinessChange", data: ["readiness": execuTorchNotLinkedMessage])
             call.reject(execuTorchNotLinkedMessage)

--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -78,6 +78,9 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
     private var execuTorchRunner: DynamicExecuTorchRunner?
     private var execuTorchChats: [String: ExecuTorchChatSession] = [:]
     private let execuTorchGenerationLock = NSLock()
+    private let execuTorchNotLinkedMessage = "ExecuTorch is not linked in this iOS app. " +
+        "It is not installed by CocoaPods; add the ExecuTorch Swift Package products " +
+        "to the app target on iOS 17+ or choose another engine."
     private var execuTorchIsGenerating = false
 
     @objc func setModel(_ call: CAPPluginCall) {
@@ -257,7 +260,9 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         guard DynamicExecuTorchRunner.isAvailable else {
-            call.reject("ExecuTorch is not linked in this iOS app. Add the ExecuTorch Swift Package products to the app target.")
+            isReady = false
+            notifyListeners("readinessChange", data: ["readiness": execuTorchNotLinkedMessage])
+            call.reject(execuTorchNotLinkedMessage)
             return
         }
 

--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -10,9 +10,6 @@ import FoundationModels
 #if canImport(MediaPipeTasksGenAI) && !targetEnvironment(macCatalyst)
 import MediaPipeTasksGenAI
 #endif
-#if canImport(ExecuTorchLLM)
-import ExecuTorchLLM
-#endif
 
 /**
  * Please read the Capacitor iOS Plugin Development Guide
@@ -81,18 +78,10 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
     private var execuTorchRunner: DynamicExecuTorchRunner?
     private var execuTorchChats: [String: ExecuTorchChatSession] = [:]
     private let execuTorchGenerationLock = NSLock()
-    private let execuTorchNotLinkedMessage = "ExecuTorch is not available in this iOS build. " +
-        "It is not installed by CocoaPods; use the Swift Package Manager integration " +
-        "on iOS 17+ or choose another engine."
+    private let execuTorchNotLinkedMessage = "ExecuTorch is not linked in this iOS app. " +
+        "It is not installed by CocoaPods; add the ExecuTorch Swift Package products " +
+        "to the app target on iOS 17+ or choose another engine."
     private var execuTorchIsGenerating = false
-
-    private var isExecuTorchRuntimeAvailable: Bool {
-        #if canImport(ExecuTorchLLM)
-        return DynamicExecuTorchRunner.isAvailable
-        #else
-        return false
-        #endif
-    }
 
     @objc func setModel(_ call: CAPPluginCall) {
         guard let path = call.getString("path") else {
@@ -270,7 +259,7 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        guard isExecuTorchRuntimeAvailable else {
+        guard DynamicExecuTorchRunner.isAvailable else {
             isReady = false
             notifyListeners("readinessChange", data: ["readiness": execuTorchNotLinkedMessage])
             call.reject(execuTorchNotLinkedMessage)


### PR DESCRIPTION
## What
- Reverted the direct ExecuTorch dependency from `Package.swift` so the plugin Swift package remains iOS 15 compatible.
- Documented how host apps can manually add ExecuTorch with Swift Package Manager when they want iOS ExecuTorch.
- Kept the iOS runtime guard so `engine: 'executorch'` rejects clearly when ExecuTorch is not linked.

## Why
- Linking ExecuTorch directly would force every SwiftPM user onto iOS 17, even when they only use Apple Intelligence or MediaPipe.
- CocoaPods does not provide ExecuTorch for this plugin, so app-side linking needs to be explicit in the README.

## How
- Removed the ExecuTorch SwiftPM package/products from `Package.swift`.
- Removed the compile-time ExecuTorch import check and use the dynamic runtime availability check instead.
- Added README steps for adding the official ExecuTorch package branch and products to the app target.

## Testing
- `bun run fmt`
- `bun run verify`
- `pod lib lint CapgoCapacitorLlm.podspec --allow-warnings --skip-tests --platforms=ios --use-static-frameworks`

## Not Tested
- Real on-device ExecuTorch generation with a host app that manually links the ExecuTorch Swift package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified ExecuTorch and MediaPipe setup requirements for iOS and Android, including Swift Package Manager integration steps and platform-specific dependency guidance.

* **Bug Fixes**
  * Enhanced error messaging and readiness state notifications when ExecuTorch is not properly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->