### PR TITLE
fix(ios): guard eager Apple Intelligence init from crashing iOS apps on Mac

### DIFF
--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -61,6 +61,16 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
 
     #if canImport(FoundationModels)
     private var appleModel: Any? = {
+        // `SystemLanguageModel.default` is not functional for an iOS/iPadOS
+        // binary running "Designed for iPad" on Apple Silicon Mac, and
+        // touching it there crashes the app during plugin instantiation —
+        // before any of the app's own platform checks get a chance to run,
+        // since Capacitor eagerly instantiates every registered plugin at
+        // bridge startup. Skip it in that environment, same as the existing
+        // Mac Catalyst guard below.
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            return nil
+        }
         if #available(iOS 26.0, *) {
             return SystemLanguageModel.default
         } else {


### PR DESCRIPTION
## Summary
- `LLMPlugin.appleModel` is a stored-property initializer, so it runs unconditionally as soon as Capacitor instantiates the plugin at bridge startup — before any host app's own platform/availability checks get a chance to run.
- It touches `SystemLanguageModel.default` whenever `#available(iOS 26.0, *)` is true. The plugin already special-cases Mac Catalyst (`targetEnvironment(macCatalyst)`), but has no guard for a plain iOS/iPadOS binary running "Designed for iPad" on an Apple Silicon Mac — a different, non-Catalyst execution path where `#available(iOS 26.0, *)` still evaluates true but `SystemLanguageModel.default` isn't functional. Touching it there crashes the app immediately during plugin registration, before any UI ever renders.
- Fix: skip the Apple Intelligence init when `ProcessInfo.processInfo.isiOSAppOnMac` is true, mirroring the existing Mac Catalyst guard. `appleModel` simply stays `nil`, and every downstream call site (`createChat`, `sendMessage`, `getReadinessStatus`) already treats a nil/non-castable `appleModel` as "unavailable" and degrades gracefully rather than crashing — no other behavior changes.
- Found and root-caused while debugging a real-world regression: a Capacitor app that added on-device AI via this plugin started crashing on launch specifically on Apple Silicon Macs (via TestFlight's "Designed for iPad" support), while working fine on iPhone/iPad.

## Test plan
- [x] `npm run swiftlint` — blocked locally by an unrelated Homebrew/SourceKit toolchain loading issue in this sandbox (`Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed`), not related to this change
- [x] `xcodebuild -scheme CapgoCapacitorLlm -destination 'generic/platform=iOS' build` succeeds with the patch applied (only a pre-existing, unrelated warning at a different line)
- [x] Verified in a downstream consumer app: patched plugin compiles cleanly for iOS Simulator via `xcodebuild`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model initialization on iOS apps running on macOS, preventing a startup issue in that environment.
  * Preserved the existing behavior for other devices and supported iOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->