### PR TITLE
fix(ios): guard eager Apple Intelligence init from crashing iOS apps on Mac

### DIFF
--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -61,6 +61,16 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
 
     #if canImport(FoundationModels)
     private var appleModel: Any? = {
+        // `SystemLanguageModel.default` is not functional for an iOS/iPadOS
+        // binary running "Designed for iPad" on Apple Silicon Mac, and
+        // touching it there crashes the app during plugin instantiation —
+        // before any of the app's own platform checks get a chance to run,
+        // since Capacitor eagerly instantiates every registered plugin at
+        // bridge startup. Skip it in that environment, same as the existing
+        // Mac Catalyst guard below.
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            return nil
+        }
         if #available(iOS 26.0, *) {
             return SystemLanguageModel.default
         } else {


### PR DESCRIPTION
## Summary
- Supersedes #15 (same fix, in-repo branch so CI and beta publish work).
- `LLMPlugin.appleModel` is a stored-property initializer, so it runs unconditionally as soon as Capacitor instantiates the plugin at bridge startup — before any host app's own platform/availability checks get a chance to run.
- It touches `SystemLanguageModel.default` whenever `#available(iOS 26.0, *)` is true. The plugin already special-cases Mac Catalyst (`targetEnvironment(macCatalyst)`), but has no guard for a plain iOS/iPadOS binary running "Designed for iPad" on an Apple Silicon Mac — a different, non-Catalyst execution path where `#available(iOS 26.0, *)` still evaluates true but `SystemLanguageModel.default` isn't functional. Touching it there crashes the app immediately during plugin registration, before any UI ever renders.
- Fix: skip the Apple Intelligence init when `ProcessInfo.processInfo.isiOSAppOnMac` is true, mirroring the existing Mac Catalyst guard. `appleModel` simply stays `nil`, and every downstream call site (`createChat`, `sendMessage`, `getReadinessStatus`) already treats a nil/non-castable `appleModel` as "unavailable" and degrades gracefully rather than crashing — no other behavior changes.

## Test plan
- [x] `bun run verify` passes locally (iOS Swift build, Android, web)
- [ ] CI green on this PR

Closes #15

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model initialization so the app no longer attempts to load the system language model when running an iOS/iPadOS app on Mac.
  * This helps avoid issues in that environment and keeps behavior consistent with supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->