### PR TITLE
[codex] Implement LiteRT-LM mobile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ On-device LLM support for Capacitor.
 
 Current platform strategy:
 
-- iOS: Apple Intelligence by default, plus LiteRT-LM `.litertlm` custom models when the plugin is integrated through Swift Package Manager
+- iOS: Apple Intelligence by default, plus LiteRT-LM `.litertlm` custom models in SwiftPM integrations when the path ends in `.litertlm` or `modelType: 'litertlm'` is passed
 - Android: LiteRT-LM for `.litertlm` bundles, with a compatibility fallback for legacy MediaPipe `.task` models
 - Web: Gemma 4 web models through `@mediapipe/tasks-genai`
 
@@ -56,7 +56,9 @@ Custom iOS LiteRT-LM path:
 
 - Available only when the plugin is integrated into the iOS app through Swift Package Manager
 - Uses the official LiteRT-LM Swift API and prebuilt iOS xcframework for `.litertlm` models
+- Selected only when the path ends in `.litertlm` or `modelType: 'litertlm'` is passed
 - CocoaPods builds keep Apple Intelligence and the legacy MediaPipe `.task` compatibility path
+- Other custom iOS model types keep the legacy MediaPipe compatibility path for backward compatibility
 
 Example:
 
@@ -150,11 +152,10 @@ await CapgoLLM.sendMessage({
   message: 'Explain why local inference is useful on mobile.',
 });
 ```
-
 ## Notes
 
 - Android now prefers LiteRT-LM and Gemma 4 style `.litertlm` bundles.
-- iOS LiteRT-LM custom-model support now uses the official LiteRT-LM Swift API and prebuilt iOS binaries, and is available only in SwiftPM integrations of this plugin.
+- iOS LiteRT-LM custom-model support now uses the official LiteRT-LM Swift API and prebuilt iOS binaries, is available only in SwiftPM integrations of this plugin, and is selected only for explicit `.litertlm` models.
 - CocoaPods builds on iOS should use Apple Intelligence or the legacy MediaPipe `.task` compatibility path.
 - Web uses Gemma 4 `*-web.task` artifacts through `@mediapipe/tasks-genai`.
 - Apple Intelligence remains the preferred default on iOS where available.
@@ -229,7 +230,7 @@ setModel(options: ModelOptions) => Promise<void>
 ```
 
 Sets the model configuration
-- iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager.
+- iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager, and are selected only when `modelType: 'litertlm'` is passed or the path ends in `.litertlm`.
 - Android: Prefer LiteRT-LM `.litertlm` bundles; legacy MediaPipe `.task` models are still supported
 - Web: Provide a web-ready model asset for `@mediapipe/tasks-genai` such as Gemma 4 `*-web.task`
 
@@ -372,14 +373,14 @@ Get the native Capacitor plugin version.
 Model configuration options
 Only `path` is required. All other properties are optional overrides.
 
-| Prop              | Type                | Description                                                                                                                                                                                                                                    |
-| ----------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`path`**        | <code>string</code> | Model path or "Apple Intelligence" for the Apple system model on iOS. On iOS, custom `.litertlm` models require the plugin to be integrated through Swift Package Manager. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. |
-| **`modelType`**   | <code>string</code> | Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. Use `litertlm` on iOS only in SwiftPM integrations.                                                            |
-| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                                                                                                                                                     |
-| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                                                                                                                                                              |
-| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                                                                                                                                                                   |
-| **`randomSeed`**  | <code>number</code> | Optional. Random seed for generation.                                                                                                                                                                                                          |
+| Prop              | Type                | Description                                                                                                                                                                                                                                                               |
+| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`path`**        | <code>string</code> | Model path or "Apple Intelligence" for the Apple system model on iOS. On iOS, custom `.litertlm` models require the plugin to be integrated through Swift Package Manager. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web.                            |
+| **`modelType`**   | <code>string</code> | Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. On iOS, LiteRT-LM is selected only when this resolves to `litertlm`; all other custom types keep the legacy MediaPipe compatibility path. |
+| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                                                                                                                                                                                |
+| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                                                                                                                                                                                         |
+| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                                                                                                                                                                                              |
+| **`randomSeed`**  | <code>number</code> | Optional. Random seed for generation.                                                                                                                                                                                                                                     |
 
 
 #### DownloadModelResult

--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -407,11 +407,7 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
         case "task":
             return .mediaPipe
         default:
-            #if canImport(LiteRTLM)
-            return .liteRtLm
-            #else
             return .mediaPipe
-            #endif
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -23,7 +23,7 @@ export interface LLMPlugin {
 
   /**
    * Sets the model configuration
-   * - iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager.
+   * - iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager, and are selected only when `modelType: 'litertlm'` is passed or the path ends in `.litertlm`.
    * - Android: Prefer LiteRT-LM `.litertlm` bundles; legacy MediaPipe `.task` models are still supported
    * - Web: Provide a web-ready model asset for `@mediapipe/tasks-genai` such as Gemma 4 `*-web.task`
    * @param options - The model configuration
@@ -191,7 +191,7 @@ export interface ReadinessChangeEvent {
 export interface ModelOptions {
   /** Model path or "Apple Intelligence" for the Apple system model on iOS. On iOS, custom `.litertlm` models require the plugin to be integrated through Swift Package Manager. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. */
   path: string;
-  /** Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. Use `litertlm` on iOS only in SwiftPM integrations. */
+  /** Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. On iOS, LiteRT-LM is selected only when this resolves to `litertlm`; all other custom types keep the legacy MediaPipe compatibility path. */
   modelType?: string;
   /** Maximum number of tokens the model handles */
   maxTokens?: number;


### PR DESCRIPTION
Fixes #6

## What
- migrate the mobile plugin paths toward LiteRT-LM for Android and add a real LiteRT-LM path for iOS when the plugin is integrated through Swift Package Manager
- keep CocoaPods iOS builds on the Apple Intelligence plus legacy MediaPipe `.task` paths, with an explicit runtime error if `.litertlm` is requested there
- preserve legacy iOS custom-model selection for non-`.litertlm` values so existing callers do not silently switch from MediaPipe to LiteRT-LM
- refresh the Gemma 4 example app and docs across Android, iOS, and web so the supported model flows match the actual runtime behavior
- vendor the official LiteRT-LM Swift wrapper locally and fetch the official prebuilt iOS xcframework through SwiftPM to avoid the upstream repo checkout failure during package resolution

## Why
- issue #6 needs actual LiteRT-LM support instead of placeholder or mismatched example behavior
- Google now ships an official Swift API for LiteRT-LM, but the upstream repository checkout currently pulls a missing non-iOS Git LFS blob, which breaks SwiftPM resolution for this plugin
- the bundled example app is a CocoaPods host on iOS, so it must not advertise downloadable `.litertlm` models that only work in SwiftPM integrations
- the compatibility guard avoids a behavior break for iOS apps that omitted `modelType` or used older non-`.litertlm` values

## How
- add a local `LiteRTLM` Swift target backed by the official `CLiteRTLM.xcframework` binary target
- route iOS `.litertlm` model loading, chat creation, and streaming through LiteRT-LM `Engine` and `Conversation`
- keep Android on LiteRT-LM-first model resolution and preserve the legacy MediaPipe fallback where still needed
- select LiteRT-LM on iOS only when the path ends in `.litertlm` or `modelType: 'litertlm'` is passed
- tighten docs, example assets, plugin metadata, and web/example wiring so Gemma 4 flows line up across platforms
- include a `.webp` screenshot from the live example app state for the updated iOS model picker copy

## Screenshot
![iOS example model picker](https://raw.githubusercontent.com/Cap-go/capacitor-llm/codex/issue-6-litertlm-mobile-support-compat/output/playwright/example-ios-models.webp)

## Testing
- `bun run verify`
- `cd example-app && bun run build`
- `cd example-app && bun run test:unit -- --run`

## Not Tested
- manual inference with a real `.litertlm` bundle on an iOS device or simulator
- a fully SwiftPM-native example app launch on iOS; the bundled example app remains documented as the CocoaPods host path

Prepared with Codex.
