### PR TITLE
feat(android): add Gemini Nano system model

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ On-device LLM support for Capacitor.
 Current platform strategy:
 
 - iOS: Apple Intelligence by default, plus LiteRT-LM `.litertlm` custom models when the plugin is integrated through Swift Package Manager
-- Android: LiteRT-LM for `.litertlm` bundles, with a compatibility fallback for legacy MediaPipe `.task` models
+- Android: Gemini Nano system model on supported devices where it is already available, LiteRT-LM for `.litertlm` bundles, and a compatibility fallback for legacy MediaPipe `.task` models
 - Web: Gemma 4 web models through `@mediapipe/tasks-genai`
 
 ## Documentation
@@ -71,9 +71,17 @@ const chat = await CapgoLLM.createChat();
 
 Recommended path:
 
+- Use Gemini Nano with `path: 'Gemini Nano'` when the Android device already has it available through AICore
 - Use LiteRT-LM `.litertlm` bundles
 - Gemma 4 E2B and E4B are good default examples
 - Models are available from the public [`litert-community`](https://huggingface.co/litert-community) Hugging Face repos
+
+Gemini Nano system model example:
+
+```ts
+await CapgoLLM.setModel({ path: 'Gemini Nano' });
+const chat = await CapgoLLM.createChat();
+```
 
 Quickstart with a downloaded Gemma 4 model:
 
@@ -230,7 +238,7 @@ setModel(options: ModelOptions) => Promise<void>
 
 Sets the model configuration
 - iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager.
-- Android: Prefer LiteRT-LM `.litertlm` bundles; legacy MediaPipe `.task` models are still supported
+- Android: Use "Gemini Nano" for the AICore system model on supported devices where it is already available. Prefer LiteRT-LM `.litertlm` bundles for custom models; legacy MediaPipe `.task` models are still supported
 - Web: Provide a web-ready model asset for `@mediapipe/tasks-genai` such as Gemma 4 `*-web.task`
 
 | Param         | Type                                                  | Description               |
@@ -372,14 +380,14 @@ Get the native Capacitor plugin version.
 Model configuration options
 Only `path` is required. All other properties are optional overrides.
 
-| Prop              | Type                | Description                                                                                                                                                                                                                                    |
-| ----------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`path`**        | <code>string</code> | Model path or "Apple Intelligence" for the Apple system model on iOS. On iOS, custom `.litertlm` models require the plugin to be integrated through Swift Package Manager. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. |
-| **`modelType`**   | <code>string</code> | Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. Use `litertlm` on iOS only in SwiftPM integrations.                                                            |
-| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                                                                                                                                                     |
-| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                                                                                                                                                              |
-| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                                                                                                                                                                   |
-| **`randomSeed`**  | <code>number</code> | Optional. Random seed for generation.                                                                                                                                                                                                          |
+| Prop              | Type                | Description                                                                                                                                                                                                                                                                                                                             |
+| ----------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`path`**        | <code>string</code> | Model path, "Apple Intelligence" for the Apple system model on iOS, or "Gemini Nano" for the Android AICore system model when already available on the device. On iOS, custom `.litertlm` models require the plugin to be integrated through Swift Package Manager. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. |
+| **`modelType`**   | <code>string</code> | Optional. Model file type/extension (for example `task`, `bin`, `litertlm`, or `gemini-nano`). If not provided, it is extracted from the path. Use `litertlm` on iOS only in SwiftPM integrations.                                                                                                                                      |
+| **`maxTokens`**   | <code>number</code> | Maximum number of tokens the model handles                                                                                                                                                                                                                                                                                              |
+| **`topk`**        | <code>number</code> | Number of tokens the model considers at each step                                                                                                                                                                                                                                                                                       |
+| **`temperature`** | <code>number</code> | Amount of randomness in generation (0.0-1.0)                                                                                                                                                                                                                                                                                            |
+| **`randomSeed`**  | <code>number</code> | Optional. Random seed for generation.                                                                                                                                                                                                                                                                                                   |
 
 
 #### DownloadModelResult

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation 'com.google.ai.edge.litertlm:litertlm-android:0.10.0'
     implementation 'com.google.mediapipe:tasks-genai:0.10.24'
+    implementation 'com.google.mlkit:genai-prompt:1.0.0-beta2'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/src/main/java/ee/forgr/capgo_llm/LLM.java
+++ b/android/src/main/java/ee/forgr/capgo_llm/LLM.java
@@ -1,6 +1,7 @@
 package ee.forgr.capgo_llm;
 
 import android.content.Context;
+import android.os.Build;
 import com.google.ai.edge.litertlm.Backend;
 import com.google.ai.edge.litertlm.Content;
 import com.google.ai.edge.litertlm.Conversation;
@@ -9,24 +10,37 @@ import com.google.ai.edge.litertlm.Engine;
 import com.google.ai.edge.litertlm.EngineConfig;
 import com.google.ai.edge.litertlm.Message;
 import com.google.ai.edge.litertlm.SamplerConfig;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.mediapipe.tasks.genai.llminference.LlmInference;
 import com.google.mediapipe.tasks.genai.llminference.LlmInference.LlmInferenceOptions;
 import com.google.mediapipe.tasks.genai.llminference.LlmInferenceSession;
+import com.google.mlkit.genai.common.FeatureStatus;
+import com.google.mlkit.genai.common.StreamingCallback;
+import com.google.mlkit.genai.prompt.Candidate;
+import com.google.mlkit.genai.prompt.GenerateContentRequest;
+import com.google.mlkit.genai.prompt.GenerateContentResponse;
+import com.google.mlkit.genai.prompt.Generation;
+import com.google.mlkit.genai.prompt.TextPart;
+import com.google.mlkit.genai.prompt.java.GenerativeModelFutures;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class LLM {
 
     private enum BackendType {
         LITERT,
-        MEDIAPIPE
+        MEDIAPIPE,
+        GEMINI_NANO
     }
 
     private static final double DEFAULT_TOP_P = 0.95d;
@@ -37,6 +51,7 @@ public class LLM {
     private final Map<String, ChatSession> chatSessions;
 
     private Engine engine;
+    private GenerativeModelFutures geminiNanoModel;
     private LlmInference llmInference;
     private boolean isReady = false;
     private String modelPath = null;
@@ -122,7 +137,7 @@ public class LLM {
                 }
 
                 BackendType backend = resolveBackend(request.modelPath, request.modelType);
-                String actualPath = resolveModelPath(request.modelPath, backend);
+                String actualPath = backend == BackendType.GEMINI_NANO ? request.modelPath : resolveModelPath(request.modelPath, backend);
 
                 android.util.Log.d("LLM", "Resolved model path: " + actualPath + " using backend: " + backend);
 
@@ -133,15 +148,20 @@ public class LLM {
                         notifySupersededLoad(callback);
                         return;
                     }
-                    applyLoadedModel(request, backend, loadedEngine, null);
+                    applyLoadedModel(request, backend, loadedEngine, null, null);
                 } else {
+                    if (backend == BackendType.GEMINI_NANO) {
+                        initializeGeminiNanoModel(request, callback);
+                        return;
+                    }
+
                     LlmInference loadedInference = initializeMediaPipeModel(actualPath, request);
                     if (!isCurrentLoad(request.loadId)) {
                         closeLlmInference(loadedInference);
                         notifySupersededLoad(callback);
                         return;
                     }
-                    applyLoadedModel(request, backend, null, loadedInference);
+                    applyLoadedModel(request, backend, null, loadedInference, null);
                 }
 
                 if (callback != null) {
@@ -173,7 +193,8 @@ public class LLM {
         ModelLoadRequest request,
         BackendType backend,
         Engine loadedEngine,
-        LlmInference loadedInference
+        LlmInference loadedInference,
+        GenerativeModelFutures loadedGeminiNanoModel
     ) {
         modelPath = request.modelPath;
         modelType = request.modelType;
@@ -184,6 +205,7 @@ public class LLM {
         activeBackend = backend;
         engine = loadedEngine;
         llmInference = loadedInference;
+        geminiNanoModel = loadedGeminiNanoModel;
         isReady = true;
     }
 
@@ -210,8 +232,88 @@ public class LLM {
         return LlmInference.createFromOptions(context, options);
     }
 
+    private void initializeGeminiNanoModel(ModelLoadRequest request, ModelLoadCallback callback) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            if (callback != null) {
+                callback.onError("Gemini Nano requires Android API 26 or higher");
+            }
+            return;
+        }
+
+        GenerativeModelFutures loadedModel = GenerativeModelFutures.from(Generation.INSTANCE.getClient());
+        ListenableFuture<Integer> statusFuture = loadedModel.checkStatus();
+        statusFuture.addListener(
+            () -> {
+                try {
+                    if (!isCurrentLoad(request.loadId)) {
+                        notifySupersededLoad(callback);
+                        return;
+                    }
+
+                    Integer status = statusFuture.get();
+                    if (status == FeatureStatus.AVAILABLE) {
+                        applyLoadedModel(request, BackendType.GEMINI_NANO, null, null, loadedModel);
+                        if (callback != null) {
+                            callback.onSuccess();
+                        }
+                        return;
+                    }
+
+                    resetModelState();
+                    if (callback != null) {
+                        callback.onError("Gemini Nano is " + geminiNanoStatusName(status) + " on this device");
+                    }
+                } catch (CancellationException | ExecutionException exception) {
+                    resetModelState();
+                    if (callback != null) {
+                        callback.onError(exception.getMessage());
+                    }
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    resetModelState();
+                    if (callback != null) {
+                        callback.onError(exception.getMessage());
+                    }
+                }
+            },
+            executor
+        );
+    }
+
+    private String geminiNanoStatusName(Integer status) {
+        if (status == null) {
+            return "unknown";
+        }
+
+        switch (status) {
+            case FeatureStatus.UNAVAILABLE:
+                return "unavailable";
+            case FeatureStatus.DOWNLOADABLE:
+                return "downloadable but not downloaded";
+            case FeatureStatus.DOWNLOADING:
+                return "downloading";
+            case FeatureStatus.AVAILABLE:
+                return "available";
+            default:
+                return "unknown";
+        }
+    }
+
     private BackendType resolveBackend(String path, String modelType) {
+        if (isGeminiNanoModel(path, modelType)) {
+            return BackendType.GEMINI_NANO;
+        }
+
         return "litertlm".equals(normalizeModelType(path, modelType)) ? BackendType.LITERT : BackendType.MEDIAPIPE;
+    }
+
+    private boolean isGeminiNanoModel(String path, String modelType) {
+        String requestedModel = modelType != null && !modelType.isBlank() ? modelType : path;
+        return "gemininano".equals(normalizeSystemModelName(requestedModel));
+    }
+
+    private String normalizeSystemModelName(String value) {
+        return stripUrlSuffix(value).toLowerCase().replace("-", "").replace("_", "").replace(" ", "");
     }
 
     private String normalizeModelType(String path, String modelType) {
@@ -297,6 +399,11 @@ public class LLM {
                 throw new IllegalStateException("LiteRT-LM engine not initialized");
             }
             session = ChatSession.forLiteRt(createLiteRtConversation());
+        } else if (activeBackend == BackendType.GEMINI_NANO) {
+            if (geminiNanoModel == null) {
+                throw new IllegalStateException("Gemini Nano model not initialized");
+            }
+            session = ChatSession.forGeminiNano();
         } else {
             if (llmInference == null) {
                 throw new IllegalStateException("MediaPipe model not initialized");
@@ -325,9 +432,11 @@ public class LLM {
     public void sendMessage(String chatId, String message, MessageCallback callback) {
         ChatSession session;
         LlmInference inference;
+        GenerativeModelFutures nanoModel;
         Integer sessionTopk;
         Float sessionTemperature;
-
+        Integer sessionMaxTokens;
+        Integer sessionRandomSeed;
         synchronized (this) {
             session = chatSessions.get(chatId);
             if (session == null) {
@@ -339,12 +448,34 @@ public class LLM {
             }
 
             inference = llmInference;
+            nanoModel = geminiNanoModel;
             sessionTopk = topk;
             sessionTemperature = temperature;
+            sessionMaxTokens = maxTokens;
+            sessionRandomSeed = randomSeed;
         }
 
         if (session.backendType == BackendType.LITERT) {
             sendMessageWithLiteRt(chatId, message, session, callback);
+            return;
+        }
+
+        if (session.backendType == BackendType.GEMINI_NANO) {
+            if (nanoModel == null) {
+                throw new IllegalStateException("Gemini Nano model not ready");
+            }
+
+            sendMessageWithGeminiNano(
+                chatId,
+                message,
+                session,
+                nanoModel,
+                sessionMaxTokens,
+                sessionTopk,
+                sessionTemperature,
+                sessionRandomSeed,
+                callback
+            );
             return;
         }
 
@@ -395,6 +526,85 @@ public class LLM {
         }
 
         return builder.toString();
+    }
+
+    private void sendMessageWithGeminiNano(
+        String chatId,
+        String message,
+        ChatSession session,
+        GenerativeModelFutures nanoModel,
+        Integer sessionMaxTokens,
+        Integer sessionTopk,
+        Float sessionTemperature,
+        Integer sessionRandomSeed,
+        MessageCallback callback
+    ) {
+        synchronized (session) {
+            session.addMessage("user", message);
+        }
+
+        GenerateContentRequest.Builder requestBuilder;
+        synchronized (session) {
+            requestBuilder = new GenerateContentRequest.Builder(new TextPart(session.buildPrompt()));
+        }
+
+        requestBuilder.setMaxOutputTokens(Math.min(sessionMaxTokens, 256));
+        requestBuilder.setTopK(sessionTopk);
+        requestBuilder.setTemperature(sessionTemperature);
+        requestBuilder.setSeed(sessionRandomSeed);
+
+        StringBuffer fullResponse = new StringBuffer();
+        AtomicBoolean streamed = new AtomicBoolean(false);
+        ListenableFuture<GenerateContentResponse> responseFuture = nanoModel.generateContent(
+            requestBuilder.build(),
+            new StreamingCallback() {
+                @Override
+                public void onNewText(String additionalText) {
+                    if (additionalText == null || additionalText.isEmpty()) {
+                        return;
+                    }
+
+                    streamed.set(true);
+                    fullResponse.append(additionalText);
+                    callback.onTextReceived(chatId, additionalText, true);
+                }
+            }
+        );
+
+        responseFuture.addListener(
+            () -> {
+                try {
+                    GenerateContentResponse response = responseFuture.get();
+                    if (!streamed.get()) {
+                        String text = extractText(response);
+                        if (!text.isEmpty()) {
+                            fullResponse.append(text);
+                            callback.onTextReceived(chatId, text, true);
+                        }
+                    }
+
+                    synchronized (session) {
+                        session.addMessage("assistant", fullResponse.toString());
+                    }
+                    callback.onComplete(chatId);
+                } catch (CancellationException | ExecutionException exception) {
+                    callback.onError(exception.getMessage());
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    callback.onError(exception.getMessage());
+                }
+            },
+            executor
+        );
+    }
+
+    private String extractText(GenerateContentResponse response) {
+        if (response.getCandidates().isEmpty()) {
+            return "";
+        }
+
+        Candidate candidate = response.getCandidates().get(0);
+        return candidate.getText();
     }
 
     private void sendMessageWithMediaPipe(
@@ -501,6 +711,7 @@ public class LLM {
         closeLlmInference(llmInference);
         engine = null;
         llmInference = null;
+        geminiNanoModel = null;
         modelPath = null;
         modelType = null;
         isReady = false;
@@ -579,6 +790,10 @@ public class LLM {
 
         static ChatSession forMediaPipe() {
             return new ChatSession(BackendType.MEDIAPIPE, null);
+        }
+
+        static ChatSession forGeminiNano() {
+            return new ChatSession(BackendType.GEMINI_NANO, null);
         }
 
         void addMessage(String role, String content) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -24,7 +24,7 @@ export interface LLMPlugin {
   /**
    * Sets the model configuration
    * - iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager.
-   * - Android: Prefer LiteRT-LM `.litertlm` bundles; legacy MediaPipe `.task` models are still supported
+   * - Android: Use "Gemini Nano" for the AICore system model on supported devices where it is already available. Prefer LiteRT-LM `.litertlm` bundles for custom models; legacy MediaPipe `.task` models are still supported
    * - Web: Provide a web-ready model asset for `@mediapipe/tasks-genai` such as Gemma 4 `*-web.task`
    * @param options - The model configuration
    * @returns Promise that resolves when model is loaded
@@ -189,9 +189,9 @@ export interface ReadinessChangeEvent {
  * Only `path` is required. All other properties are optional overrides.
  */
 export interface ModelOptions {
-  /** Model path or "Apple Intelligence" for the Apple system model on iOS. On iOS, custom `.litertlm` models require the plugin to be integrated through Swift Package Manager. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. */
+  /** Model path, "Apple Intelligence" for the Apple system model on iOS, or "Gemini Nano" for the Android AICore system model when already available on the device. On iOS, custom `.litertlm` models require the plugin to be integrated through Swift Package Manager. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. */
   path: string;
-  /** Optional. Model file type/extension (for example `task`, `bin`, or `litertlm`). If not provided, it is extracted from the path. Use `litertlm` on iOS only in SwiftPM integrations. */
+  /** Optional. Model file type/extension (for example `task`, `bin`, `litertlm`, or `gemini-nano`). If not provided, it is extracted from the path. Use `litertlm` on iOS only in SwiftPM integrations. */
   modelType?: string;
   /** Maximum number of tokens the model handles */
   maxTokens?: number;


### PR DESCRIPTION
## What
- Add Android Gemini Nano system-model support through ML Kit GenAI Prompt API / AICore.
- Document `path: 'Gemini Nano'` for Android devices where the system model is already available.

## Why
- Mirror the iOS Apple Intelligence system-model path for Android devices that already have Gemini Nano embedded and available on-device.

## How
- Added the official ML Kit Prompt API dependency.
- Added a `GEMINI_NANO` Android backend selected by `path: 'Gemini Nano'` or `modelType: 'gemini-nano'`.
- Check ML Kit `FeatureStatus` and only load when it is `AVAILABLE`; this does not start a model download.
- Stream Gemini Nano output through the existing `textFromAi` / `aiFinished` events.
- Implemented by Codex after checking the official Android Gemini Nano and ML Kit Prompt API docs:
  - https://developer.android.com/ai/gemini-nano
  - https://developers.google.com/ml-kit/genai/prompt/android/get-started

## Testing
- `bun run fmt`
- `bun run build`
- `bun run verify:android`
- `bun run verify`

## Not Tested
- Runtime Gemini Nano inference on a supported physical Android device with AICore / Gemini Nano already available.