### PR TITLE
fix(ios): preserve legacy model selection after LiteRT-LM migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ On-device LLM support for Capacitor.
 
 Current platform strategy:
 
-- iOS: Apple Intelligence by default, plus LiteRT-LM `.litertlm` custom models when the plugin is integrated through Swift Package Manager
+- iOS: Apple Intelligence by default, plus LiteRT-LM `.litertlm` custom models in SwiftPM integrations when the path ends in `.litertlm` or `modelType: 'litertlm'` is passed
 - Android: Gemini Nano system model on supported devices where it is already available, LiteRT-LM for `.litertlm` bundles, and a compatibility fallback for legacy MediaPipe `.task` models
 - Web: Gemma 4 web models through `@mediapipe/tasks-genai`
 
@@ -56,7 +56,9 @@ Custom iOS LiteRT-LM path:
 
 - Available only when the plugin is integrated into the iOS app through Swift Package Manager
 - Uses the official LiteRT-LM Swift API and prebuilt iOS xcframework for `.litertlm` models
+- Selected only when the path ends in `.litertlm` or `modelType: 'litertlm'` is passed
 - CocoaPods builds keep Apple Intelligence and the legacy MediaPipe `.task` compatibility path
+- Other custom iOS model types keep the legacy MediaPipe compatibility path for backward compatibility
 
 Example:
 
@@ -158,11 +160,10 @@ await CapgoLLM.sendMessage({
   message: 'Explain why local inference is useful on mobile.',
 });
 ```
-
 ## Notes
 
 - Android now prefers LiteRT-LM and Gemma 4 style `.litertlm` bundles.
-- iOS LiteRT-LM custom-model support now uses the official LiteRT-LM Swift API and prebuilt iOS binaries, and is available only in SwiftPM integrations of this plugin.
+- iOS LiteRT-LM custom-model support now uses the official LiteRT-LM Swift API and prebuilt iOS binaries, is available only in SwiftPM integrations of this plugin, and is selected only for explicit `.litertlm` models.
 - CocoaPods builds on iOS should use Apple Intelligence or the legacy MediaPipe `.task` compatibility path.
 - Web uses Gemma 4 `*-web.task` artifacts through `@mediapipe/tasks-genai`.
 - Apple Intelligence remains the preferred default on iOS where available.
@@ -237,7 +238,7 @@ setModel(options: ModelOptions) => Promise<void>
 ```
 
 Sets the model configuration
-- iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager.
+- iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager, and are selected only when `modelType: 'litertlm'` is passed or the path ends in `.litertlm`.
 - Android: Use "Gemini Nano" for the AICore system model on supported devices where it is already available. Prefer LiteRT-LM `.litertlm` bundles for custom models; legacy MediaPipe `.task` models are still supported
 - Web: Provide a web-ready model asset for `@mediapipe/tasks-genai` such as Gemma 4 `*-web.task`
 
@@ -383,7 +384,7 @@ Only `path` is required. All other properties are optional overrides.
 | Prop              | Type                        | Description                                                                                                                                                                                                                                                                                                                             | Since |
 | ----------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
 | **`path`**        | <code>string</code>         | Model path, "Apple Intelligence" for the Apple system model on iOS, or "Gemini Nano" for the Android AICore system model when already available on the device. On iOS, custom `.litertlm` models require the plugin to be integrated through Swift Package Manager. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. |       |
-| **`modelType`**   | <code>string</code>         | Optional. Model file type/extension (for example `task`, `bin`, `litertlm`, or `gemini-nano`). If not provided, it is extracted from the path. Use `litertlm` on iOS only in SwiftPM integrations.                                                                                                                                      |       |
+| **`modelType`**   | <code>string</code>         | Optional. Model file type/extension (for example `task`, `bin`, `litertlm`, or `gemini-nano`). If not provided, it is extracted from the path. On iOS, LiteRT-LM is selected only when this resolves to `litertlm`; all other custom types keep the legacy MediaPipe compatibility path.                                                |       |
 | **`maxTokens`**   | <code>number</code>         | Maximum number of tokens the model handles                                                                                                                                                                                                                                                                                              |       |
 | **`topk`**        | <code>number</code>         | Number of tokens the model considers at each step                                                                                                                                                                                                                                                                                       |       |
 | **`temperature`** | <code>number</code>         | Amount of randomness in generation (0.0-1.0)                                                                                                                                                                                                                                                                                            |       |

--- a/ios/Sources/LLMPlugin/LLMPlugin.swift
+++ b/ios/Sources/LLMPlugin/LLMPlugin.swift
@@ -412,11 +412,7 @@ public class LLMPlugin: CAPPlugin, CAPBridgedPlugin {
         case "task":
             return .mediaPipe
         default:
-            #if canImport(LiteRTLM)
-            return .liteRtLm
-            #else
             return .mediaPipe
-            #endif
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -23,7 +23,7 @@ export interface LLMPlugin {
 
   /**
    * Sets the model configuration
-   * - iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager.
+   * - iOS: Use "Apple Intelligence" as path for the system model. Custom LiteRT-LM `.litertlm` models are supported on iOS only when this plugin is integrated through Swift Package Manager, and are selected only when `modelType: 'litertlm'` is passed or the path ends in `.litertlm`.
    * - Android: Use "Gemini Nano" for the AICore system model on supported devices where it is already available. Prefer LiteRT-LM `.litertlm` bundles for custom models; legacy MediaPipe `.task` models are still supported
    * - Web: Provide a web-ready model asset for `@mediapipe/tasks-genai` such as Gemma 4 `*-web.task`
    * @param options - The model configuration
@@ -191,7 +191,7 @@ export interface ReadinessChangeEvent {
 export interface ModelOptions {
   /** Model path, "Apple Intelligence" for the Apple system model on iOS, or "Gemini Nano" for the Android AICore system model when already available on the device. On iOS, custom `.litertlm` models require the plugin to be integrated through Swift Package Manager. Gemma 4 examples use `.litertlm` on mobile and `*-web.task` on web. */
   path: string;
-  /** Optional. Model file type/extension (for example `task`, `bin`, `litertlm`, or `gemini-nano`). If not provided, it is extracted from the path. Use `litertlm` on iOS only in SwiftPM integrations. */
+  /** Optional. Model file type/extension (for example `task`, `bin`, `litertlm`, or `gemini-nano`). If not provided, it is extracted from the path. On iOS, LiteRT-LM is selected only when this resolves to `litertlm`; all other custom types keep the legacy MediaPipe compatibility path. */
   modelType?: string;
   /** Maximum number of tokens the model handles */
   maxTokens?: number;


### PR DESCRIPTION
## What
- preserve legacy iOS custom-model selection for non-`.litertlm` values after the LiteRT-LM migration
- document that iOS LiteRT-LM is selected only for explicit `.litertlm` inputs while older custom-model paths keep the legacy MediaPipe compatibility path

## Why
- the LiteRT-LM migration in #18 made SwiftPM iOS builds default unknown custom model types to LiteRT-LM when `modelType` was omitted or non-`.litertlm`
- that is a behavior change for existing callers and is broader than the intended migration scope

## How
- keep the LiteRT-LM runtime guards exactly as they are and change only the iOS model-kind fallback so unknown custom types resolve to MediaPipe instead of LiteRT-LM
- update the public TypeScript docs and generated README text so the selection rule is explicit for users

## Testing
- `bun run verify:android`
- `bun run verify:web`
- `cd example-app && bun run build`
- `cd example-app && bun run test:unit -- --run`
- GitHub Actions will validate the iOS build on the PR branch

## Not Tested
- `bun run verify:ios` is blocked locally on this machine because Xcode no longer has the iOS 26.4 platform installed, so `generic/platform=iOS` has no eligible local destination
- manual inference with a real `.litertlm` bundle on an iOS device or simulator

Prepared with Codex.
