### PR TITLE
ci: use npm stage publish for 2FA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,16 +45,32 @@ jobs:
         with:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
-      - name: Publish to npm
+      - name: Install npm CLI for staged publishing
+        run: npm install -g npm@^11.15.0
+      - name: Stage publish to npm
         if: ${{ !contains(github.ref, '-alpha.') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --provenance --access public
-      - name: Publish to npm with next tag
+        run: |
+          npm --version
+          npm stage publish --provenance --access public --ignore-scripts
+      - name: Stage publish to npm with next tag
         if: ${{ contains(github.ref, '-alpha.') }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag next --provenance --access public
+        run: |
+          npm --version
+          npm stage publish --tag next --provenance --access public --ignore-scripts
+      - name: Request stage approval
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.NPM_STAGE_DISPATCH_TOKEN }}
+        run: |
+          gh api --method POST repos/Cap-go/automations/dispatches \
+            -f event_type=npm-stage-approve \
+            -f "client_payload[repository]=${GITHUB_REPOSITORY}" \
+            -f "client_payload[run_id]=${GITHUB_RUN_ID}" \
+            -f "client_payload[package]=$(node -p "require('./package.json').name")"
       - name: Create GitHub release
         id: create_release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/pr_beta_publish.yml
+++ b/.github/workflows/pr_beta_publish.yml
@@ -123,7 +123,7 @@ jobs:
               '',
               `Requested by @${actor}.`,
               '',
-              `This run will stage the PR head for the \`beta\` npm tag. Cap-go/automations approves it with 2FA.`,
+              `This run will publish the PR head to the \`beta\` npm tag.`,
               '',
               `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             ].join('\n');
@@ -244,7 +244,7 @@ jobs:
               `Source: \`${shortSha}\``,
               `Requested by @${actor}`,
               '',
-              'Latest beta (after Cap-go/automations approves the stage):',
+              'Latest beta:',
               '```sh',
               `bun add ${packageName}@beta`,
               `bun add ${packageName}@${version}`,

--- a/.github/workflows/pr_beta_publish.yml
+++ b/.github/workflows/pr_beta_publish.yml
@@ -123,7 +123,7 @@ jobs:
               '',
               `Requested by @${actor}.`,
               '',
-              `This run will publish the PR head to the \`beta\` npm tag and refresh \`pr-${prNumber}\`.`,
+              `This run will stage the PR head for the \`beta\` npm tag. Cap-go/automations approves it with 2FA.`,
               '',
               `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             ].join('\n');

--- a/.github/workflows/pr_beta_publish.yml
+++ b/.github/workflows/pr_beta_publish.yml
@@ -201,16 +201,26 @@ jobs:
           node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Publish to npm beta
+      - name: Install npm CLI for staged publishing
+        run: npm install -g npm@^11.15.0
+
+      - name: Stage publish to npm beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag beta --provenance --access public --ignore-scripts
+        run: |
+          npm --version
+          npm stage publish --tag beta --provenance --access public --ignore-scripts
 
-      - name: Add PR dist-tag
+
+      - name: Request stage approval
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm dist-tag add "${{ steps.version.outputs.package_name }}@${{ steps.version.outputs.version }}" "pr-${{ steps.pr.outputs.pr_number }}"
-
+          GH_TOKEN: ${{ secrets.NPM_STAGE_DISPATCH_TOKEN }}
+        run: |
+          gh api --method POST repos/Cap-go/automations/dispatches \
+            -f event_type=npm-stage-approve \
+            -f "client_payload[repository]=${GITHUB_REPOSITORY}" \
+            -f "client_payload[run_id]=${GITHUB_RUN_ID}" \
+            -f "client_payload[package]=${{ steps.version.outputs.package_name }}"
       - name: Publish success comment
         if: ${{ success() }}
         uses: actions/github-script@v9.0.0

--- a/.github/workflows/pr_beta_publish.yml
+++ b/.github/workflows/pr_beta_publish.yml
@@ -213,6 +213,7 @@ jobs:
 
 
       - name: Request stage approval
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.NPM_STAGE_DISPATCH_TOKEN }}
         run: |
@@ -237,20 +238,16 @@ jobs:
               '',
               '## Beta npm build',
               '',
-              'Status: published',
+              'Status: staged',
               '',
               `Version: \`${version}\``,
               `Source: \`${shortSha}\``,
               `Requested by @${actor}`,
               '',
-              'Latest beta:',
+              'Latest beta (after Cap-go/automations approves the stage):',
               '```sh',
               `bun add ${packageName}@beta`,
-              '```',
-              '',
-              'This PR only:',
-              '```sh',
-              `bun add ${packageName}@pr-${prNumber}`,
+              `bun add ${packageName}@${version}`,
               '```',
               '',
               `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,3 +123,4 @@ We welcome contributions, including AI-generated pull requests. Every PR must in
 - Keep temporary files clean: delete or mark with `deleteOnExit` after use.
 - `dist/` is fully regenerated on every build — never edit generated files.
 - Use Bun for everything. Do not use npm or npx. Use `bunx` if you need to run a package binary.
+- Production and PR beta publishes use `npm stage publish`. Cap-go/automations approves the stage (2FA). Plugin CI only has the org `NPM_TOKEN`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,4 +123,4 @@ We welcome contributions, including AI-generated pull requests. Every PR must in
 - Keep temporary files clean: delete or mark with `deleteOnExit` after use.
 - `dist/` is fully regenerated on every build — never edit generated files.
 - Use Bun for everything. Do not use npm or npx. Use `bunx` if you need to run a package binary.
-- Production and PR beta publishes use `npm stage publish`. Cap-go/automations approves the stage (2FA). Plugin CI only has the org `NPM_TOKEN`.
+- Production and PR beta publishes use `npm stage publish`. Plugin CI only has the org `NPM_TOKEN`.


### PR DESCRIPTION
## What
- Switch production and PR beta publishes from `npm publish` to `npm stage publish`.

## Why
- npm no longer allows long-lived unattended publish tokens.

## How
- Plugin CI stages the package with the org `NPM_TOKEN`.

## Testing
- Same change already shipped on `@capgo/capacitor-wifi`.

## Not Tested
- This repo's next GitHub release / `/publish-beta` on a live PR.
